### PR TITLE
Don't try to load mod zips when in-editor

### DIFF
--- a/Core/Main.gd
+++ b/Core/Main.gd
@@ -61,9 +61,20 @@ func _load_mods():
 	if _mods_loaded:
 		return
 
+	# This function only needs to be run for builds, as the Mods folder already
+	# exists when running in-editor.
+	if OS.has_feature("editor"):
+		print("skipping mod loading because we are in-editor...")
+		_mods_loaded = true
+		return
+
 	# Scan for mods and add them.
-	print("loading mods...")
 	var mods_dir : String = OS.get_executable_path().get_base_dir().path_join("Mods")
+	if not DirAccess.dir_exists_absolute(mods_dir):
+		print("mods folder \"", mods_dir, "\" does not exist")
+		return
+
+	print("loading mods from \"", mods_dir, "\"...")
 	var mods_zip_list : PackedStringArray = DirAccess.get_files_at(mods_dir)
 	for mod_zip in mods_zip_list:
 		print("  loading: ", mod_zip)


### PR DESCRIPTION
This fixes loading mods both when running from the project and also from a build.

On Linux, if Godot is installed using a package manager, the original code believes that the Mods folder is located at `/usr/bin/Mods`. This doesn't seem intended, as the project comes with a Mod folder included and exporting the project also creates the Mod folder where the built executable is located.

I would normally just change the filepath to load the Mods folder relative to wherever the project is located [by using `res://`](https://docs.godotengine.org/en/4.3/tutorials/io/data_paths.html#accessing-files-in-the-project-folder-res), but I think it would be nice to have a proper path in the logs. So, we also need to use `globalize_path` to get an absolute path formatted the way a user might expect it for the operating system they are on.

Unfortunately, this function doesn't support exported builds. So, we have to build the path manually for exported builds and I've done it [the way the documentation for `globalize_path` recommends](https://docs.godotengine.org/en/stable/classes/class_projectsettings.html#class-projectsettings-method-globalize-path).
