### PR TITLE
ModWindow: Prevent mouse wheel input from propagating to parent

### DIFF
--- a/Core/UI/ModsWindow.tscn
+++ b/Core/UI/ModsWindow.tscn
@@ -6,6 +6,7 @@
 [node name="ModsWindow" instance=ExtResource("1_sdail")]
 offset_right = 563.0
 offset_bottom = 380.0
+mouse_force_pass_scroll_events = false
 script = ExtResource("2_whal8")
 label_text = "Mods"
 


### PR DESCRIPTION
### Description

This fixes the issue of the scroll wheel event from propagating through sub-windows to the main scene when the mouse is hovering over the window. Note that this will cause all wheel input to not travel through to the scene when hovering over any ModWindow object.

### Motivation and Context

Main scene has the unwanted effect of zooming in and out whenever wheel events aren't handled by any particular control in the tree of any ModWindow.