### PR TITLE
Hide window borders along with UI

### DIFF
--- a/Core/Main.gd
+++ b/Core/Main.gd
@@ -129,6 +129,7 @@ func _input(event):
 		if event.pressed:
 			if event.keycode == KEY_ESCAPE:
 				%UI_Root.set_visible(not %UI_Root.visible)
+				get_viewport().borderless = not %UI_Root.visible
 
 func is_dev_mode():
 	return ("--dev" in OS.get_cmdline_args())


### PR DESCRIPTION
I'm using the COSMIC desktop environment.  When I capture the SnekStudio window (using the ScreenCast portal), it includes the compositor-rendered window decorations.  This patch makes it so that when the UI is hidden, so are the window decorations, so that it's possible to capture just the contents of the window, even with capture implementations that include the decorations.