### PR TITLE
Add nightly build workflow

### DIFF
--- a/.github/workflows/check_update.yml
+++ b/.github/workflows/check_update.yml
@@ -1,0 +1,30 @@
+name: Check for updates
+
+on:
+  schedule:
+  - cron: "0 0 * * *"
+  workflow_dispatch: 
+
+jobs:
+  release-check:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    outputs:
+      run_nightly_build: ${{ steps.check.outputs.different_hash }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: '0'
+
+      - name: Check if there was a nightly build for the latest commit
+        id: check
+        run: |
+          set -e
+          [ "$(git rev-parse nightly)" == "$(git rev-parse HEAD~0)" ] || echo "different_hash=true" >> $GITHUB_OUTPUT
+
+  run-nightly-build:
+    needs: release-check
+    if: needs.release-check.outputs.run_nightly_build
+    uses: ./.github/workflows/nightly.yml
+    secrets: inherit

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,63 @@
+name: Nightly build
+
+on:
+  workflow_dispatch: 
+  workflow_call:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container: debian:bookworm
+
+    steps:
+      # Install git.
+    - name: Git
+      run: |
+        apt-get update
+        apt-get install -y git
+
+      # check out git repository.
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        submodules: true
+        fetch-depth: '0'
+        fetch-tags: true
+
+    - name: Set nightly version in app
+      run: |
+        git config --global --add safe.directory /__w/SnekStudio/SnekStudio
+        sed -i "s/config\/name=.*/config\/name=\"SnekStudioNightly\"/" project.godot
+        sed -i "s/config\/version=.*/config\/version=\"$(git describe --tags --exclude nightly)\"/" project.godot
+
+      # Do the build.
+    - name: Build
+      run: |
+        Build/run_this_inside_debian_container_to_build.bsh
+
+    - name: 🏷️ Create/update nightly tag
+      uses: actions/github-script@v7
+      with:
+        script: |
+          github.rest.git.createRef({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            ref: 'refs/tags/nightly',
+            sha: context.sha
+          }).catch(err => {
+            if (err.status !== 422) throw err;
+            github.rest.git.updateRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: 'tags/nightly',
+              sha: context.sha
+            });
+          })
+
+    - name: Release to nightly tag
+      uses: softprops/action-gh-release@v2
+      with:
+        name: Nightly build
+        body: Auto generated release
+        tag_name: nightly
+        files: "Build/Builds/Dist/SnekStudio_*"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -54,6 +54,14 @@ jobs:
             });
           })
 
+    - name: Delete old release assets
+      uses: mknejp/delete-release-assets@v1
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        tag: nightly
+        assets: |
+          *
+
     - name: Release to nightly tag
       uses: softprops/action-gh-release@v2
       with:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -60,4 +60,5 @@ jobs:
         name: Nightly build
         body: Auto generated release
         tag_name: nightly
+        prerelease: true
         files: "Build/Builds/Dist/SnekStudio_*"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -28,7 +28,7 @@ jobs:
       run: |
         git config --global --add safe.directory /__w/SnekStudio/SnekStudio
         sed -i "s/config\/name=.*/config\/name=\"SnekStudioNightly\"/" project.godot
-        sed -i "s/config\/version=.*/config\/version=\"$(git describe --tags --exclude nightly)\"/" project.godot
+        sed -i "s/config\/version=.*/config\/version=\"$(git describe --tags --exclude nightly | cut -c2-)\"/" project.godot
 
       # Do the build.
     - name: Build


### PR DESCRIPTION
Besides running nightly, there are some extra features in this workflow

* Runs builds only if there were changes in the main branch or if the latest build was unsuccessful
* Changes the project name to SnakeStudioNightly and uses git to calculate the version
* Workflows can get triggered manually through the github interface

Hope this is useful :)

![image](https://github.com/user-attachments/assets/08afcb38-a5b2-4988-9de2-5e70d74c6f64)
