### PR TITLE
Import textures in S3TC and ASTC

### DIFF
--- a/Mods/HeadPats/Resources/Sprites/frame0000.png.import
+++ b/Mods/HeadPats/Resources/Sprites/frame0000.png.import
@@ -4,15 +4,16 @@ importer="texture"
 type="CompressedTexture2D"
 uid="uid://dvs43oql2xf3k"
 path.s3tc="res://.godot/imported/frame0000.png-4a98cff6fe33d6acd4aaa14278abe5cd.s3tc.ctex"
+path.etc2="res://.godot/imported/frame0000.png-4a98cff6fe33d6acd4aaa14278abe5cd.etc2.ctex"
 metadata={
-"imported_formats": ["s3tc_bptc"],
+"imported_formats": ["s3tc_bptc", "etc2_astc"],
 "vram_texture": true
 }
 
 [deps]
 
 source_file="res://Mods/HeadPats/Resources/Sprites/frame0000.png"
-dest_files=["res://.godot/imported/frame0000.png-4a98cff6fe33d6acd4aaa14278abe5cd.s3tc.ctex"]
+dest_files=["res://.godot/imported/frame0000.png-4a98cff6fe33d6acd4aaa14278abe5cd.s3tc.ctex", "res://.godot/imported/frame0000.png-4a98cff6fe33d6acd4aaa14278abe5cd.etc2.ctex"]
 
 [params]
 

--- a/Mods/HeadPats/Resources/Sprites/frame0001.png.import
+++ b/Mods/HeadPats/Resources/Sprites/frame0001.png.import
@@ -4,15 +4,16 @@ importer="texture"
 type="CompressedTexture2D"
 uid="uid://dyfh2n4osw4yr"
 path.s3tc="res://.godot/imported/frame0001.png-877e0add4373907387ec85a52663f362.s3tc.ctex"
+path.etc2="res://.godot/imported/frame0001.png-877e0add4373907387ec85a52663f362.etc2.ctex"
 metadata={
-"imported_formats": ["s3tc_bptc"],
+"imported_formats": ["s3tc_bptc", "etc2_astc"],
 "vram_texture": true
 }
 
 [deps]
 
 source_file="res://Mods/HeadPats/Resources/Sprites/frame0001.png"
-dest_files=["res://.godot/imported/frame0001.png-877e0add4373907387ec85a52663f362.s3tc.ctex"]
+dest_files=["res://.godot/imported/frame0001.png-877e0add4373907387ec85a52663f362.s3tc.ctex", "res://.godot/imported/frame0001.png-877e0add4373907387ec85a52663f362.etc2.ctex"]
 
 [params]
 

--- a/Mods/HeadPats/Resources/Sprites/frame0002.png.import
+++ b/Mods/HeadPats/Resources/Sprites/frame0002.png.import
@@ -4,15 +4,16 @@ importer="texture"
 type="CompressedTexture2D"
 uid="uid://dr6mq1v8fc2g5"
 path.s3tc="res://.godot/imported/frame0002.png-ddcf5f52c8d0a190ac0d50e95a8a08ab.s3tc.ctex"
+path.etc2="res://.godot/imported/frame0002.png-ddcf5f52c8d0a190ac0d50e95a8a08ab.etc2.ctex"
 metadata={
-"imported_formats": ["s3tc_bptc"],
+"imported_formats": ["s3tc_bptc", "etc2_astc"],
 "vram_texture": true
 }
 
 [deps]
 
 source_file="res://Mods/HeadPats/Resources/Sprites/frame0002.png"
-dest_files=["res://.godot/imported/frame0002.png-ddcf5f52c8d0a190ac0d50e95a8a08ab.s3tc.ctex"]
+dest_files=["res://.godot/imported/frame0002.png-ddcf5f52c8d0a190ac0d50e95a8a08ab.s3tc.ctex", "res://.godot/imported/frame0002.png-ddcf5f52c8d0a190ac0d50e95a8a08ab.etc2.ctex"]
 
 [params]
 

--- a/Mods/HeadPats/Resources/Sprites/frame0003.png.import
+++ b/Mods/HeadPats/Resources/Sprites/frame0003.png.import
@@ -4,15 +4,16 @@ importer="texture"
 type="CompressedTexture2D"
 uid="uid://b716n82r8ynjw"
 path.s3tc="res://.godot/imported/frame0003.png-4668c9537b07717b6303b25704d9013a.s3tc.ctex"
+path.etc2="res://.godot/imported/frame0003.png-4668c9537b07717b6303b25704d9013a.etc2.ctex"
 metadata={
-"imported_formats": ["s3tc_bptc"],
+"imported_formats": ["s3tc_bptc", "etc2_astc"],
 "vram_texture": true
 }
 
 [deps]
 
 source_file="res://Mods/HeadPats/Resources/Sprites/frame0003.png"
-dest_files=["res://.godot/imported/frame0003.png-4668c9537b07717b6303b25704d9013a.s3tc.ctex"]
+dest_files=["res://.godot/imported/frame0003.png-4668c9537b07717b6303b25704d9013a.s3tc.ctex", "res://.godot/imported/frame0003.png-4668c9537b07717b6303b25704d9013a.etc2.ctex"]
 
 [params]
 

--- a/Mods/HeadPats/Resources/Sprites/frame0004.png.import
+++ b/Mods/HeadPats/Resources/Sprites/frame0004.png.import
@@ -4,15 +4,16 @@ importer="texture"
 type="CompressedTexture2D"
 uid="uid://dc7nxf6nh47c4"
 path.s3tc="res://.godot/imported/frame0004.png-4286ea72d185f5d58cd1edf9e5ffb960.s3tc.ctex"
+path.etc2="res://.godot/imported/frame0004.png-4286ea72d185f5d58cd1edf9e5ffb960.etc2.ctex"
 metadata={
-"imported_formats": ["s3tc_bptc"],
+"imported_formats": ["s3tc_bptc", "etc2_astc"],
 "vram_texture": true
 }
 
 [deps]
 
 source_file="res://Mods/HeadPats/Resources/Sprites/frame0004.png"
-dest_files=["res://.godot/imported/frame0004.png-4286ea72d185f5d58cd1edf9e5ffb960.s3tc.ctex"]
+dest_files=["res://.godot/imported/frame0004.png-4286ea72d185f5d58cd1edf9e5ffb960.s3tc.ctex", "res://.godot/imported/frame0004.png-4286ea72d185f5d58cd1edf9e5ffb960.etc2.ctex"]
 
 [params]
 

--- a/Mods/HeadPats/Resources/Sprites/frame0005.png.import
+++ b/Mods/HeadPats/Resources/Sprites/frame0005.png.import
@@ -4,15 +4,16 @@ importer="texture"
 type="CompressedTexture2D"
 uid="uid://dm8lacpvr2c1b"
 path.s3tc="res://.godot/imported/frame0005.png-2c4e9d36ba9475a7ed1dda81189284ef.s3tc.ctex"
+path.etc2="res://.godot/imported/frame0005.png-2c4e9d36ba9475a7ed1dda81189284ef.etc2.ctex"
 metadata={
-"imported_formats": ["s3tc_bptc"],
+"imported_formats": ["s3tc_bptc", "etc2_astc"],
 "vram_texture": true
 }
 
 [deps]
 
 source_file="res://Mods/HeadPats/Resources/Sprites/frame0005.png"
-dest_files=["res://.godot/imported/frame0005.png-2c4e9d36ba9475a7ed1dda81189284ef.s3tc.ctex"]
+dest_files=["res://.godot/imported/frame0005.png-2c4e9d36ba9475a7ed1dda81189284ef.s3tc.ctex", "res://.godot/imported/frame0005.png-2c4e9d36ba9475a7ed1dda81189284ef.etc2.ctex"]
 
 [params]
 

--- a/Mods/ThrownObjects/Objects/Bastard/bastard42_baking3_Receiver top_Bake1_PBR_Diffuse.png.import
+++ b/Mods/ThrownObjects/Objects/Bastard/bastard42_baking3_Receiver top_Bake1_PBR_Diffuse.png.import
@@ -4,8 +4,9 @@ importer="texture"
 type="CompressedTexture2D"
 uid="uid://7wq453mvnqb7"
 path.s3tc="res://.godot/imported/bastard42_baking3_Receiver top_Bake1_PBR_Diffuse.png-82231d9c1b7612a5dd52ada36ef399d4.s3tc.ctex"
+path.etc2="res://.godot/imported/bastard42_baking3_Receiver top_Bake1_PBR_Diffuse.png-82231d9c1b7612a5dd52ada36ef399d4.etc2.ctex"
 metadata={
-"imported_formats": ["s3tc_bptc"],
+"imported_formats": ["s3tc_bptc", "etc2_astc"],
 "vram_texture": true
 }
 generator_parameters={}
@@ -13,7 +14,7 @@ generator_parameters={}
 [deps]
 
 source_file="res://Mods/ThrownObjects/Objects/Bastard/bastard42_baking3_Receiver top_Bake1_PBR_Diffuse.png"
-dest_files=["res://.godot/imported/bastard42_baking3_Receiver top_Bake1_PBR_Diffuse.png-82231d9c1b7612a5dd52ada36ef399d4.s3tc.ctex"]
+dest_files=["res://.godot/imported/bastard42_baking3_Receiver top_Bake1_PBR_Diffuse.png-82231d9c1b7612a5dd52ada36ef399d4.s3tc.ctex", "res://.godot/imported/bastard42_baking3_Receiver top_Bake1_PBR_Diffuse.png-82231d9c1b7612a5dd52ada36ef399d4.etc2.ctex"]
 
 [params]
 

--- a/Mods/ThrownObjects/Objects/Bastard/bastard42_baking3_Receiver top_Bake1_PBR_Metalness-Receiver top_Bake1_PBR_Roughness.png.import
+++ b/Mods/ThrownObjects/Objects/Bastard/bastard42_baking3_Receiver top_Bake1_PBR_Metalness-Receiver top_Bake1_PBR_Roughness.png.import
@@ -4,8 +4,9 @@ importer="texture"
 type="CompressedTexture2D"
 uid="uid://bvar4bphao6uh"
 path.s3tc="res://.godot/imported/bastard42_baking3_Receiver top_Bake1_PBR_Metalness-Receiver top_Bake1_PBR_Roughness.png-651a4e0c85e357b53fb0e794418706f4.s3tc.ctex"
+path.etc2="res://.godot/imported/bastard42_baking3_Receiver top_Bake1_PBR_Metalness-Receiver top_Bake1_PBR_Roughness.png-651a4e0c85e357b53fb0e794418706f4.etc2.ctex"
 metadata={
-"imported_formats": ["s3tc_bptc"],
+"imported_formats": ["s3tc_bptc", "etc2_astc"],
 "vram_texture": true
 }
 generator_parameters={}
@@ -13,7 +14,7 @@ generator_parameters={}
 [deps]
 
 source_file="res://Mods/ThrownObjects/Objects/Bastard/bastard42_baking3_Receiver top_Bake1_PBR_Metalness-Receiver top_Bake1_PBR_Roughness.png"
-dest_files=["res://.godot/imported/bastard42_baking3_Receiver top_Bake1_PBR_Metalness-Receiver top_Bake1_PBR_Roughness.png-651a4e0c85e357b53fb0e794418706f4.s3tc.ctex"]
+dest_files=["res://.godot/imported/bastard42_baking3_Receiver top_Bake1_PBR_Metalness-Receiver top_Bake1_PBR_Roughness.png-651a4e0c85e357b53fb0e794418706f4.s3tc.ctex", "res://.godot/imported/bastard42_baking3_Receiver top_Bake1_PBR_Metalness-Receiver top_Bake1_PBR_Roughness.png-651a4e0c85e357b53fb0e794418706f4.etc2.ctex"]
 
 [params]
 

--- a/Mods/ThrownObjects/Objects/Bastard/bastard42_baking3_Receiver top_Bake1_PBR_Normal.png.import
+++ b/Mods/ThrownObjects/Objects/Bastard/bastard42_baking3_Receiver top_Bake1_PBR_Normal.png.import
@@ -4,8 +4,9 @@ importer="texture"
 type="CompressedTexture2D"
 uid="uid://dekbg40qwe471"
 path.s3tc="res://.godot/imported/bastard42_baking3_Receiver top_Bake1_PBR_Normal.png-e50d6323c55ab3a15397754ed4496e2d.s3tc.ctex"
+path.etc2="res://.godot/imported/bastard42_baking3_Receiver top_Bake1_PBR_Normal.png-e50d6323c55ab3a15397754ed4496e2d.etc2.ctex"
 metadata={
-"imported_formats": ["s3tc_bptc"],
+"imported_formats": ["s3tc_bptc", "etc2_astc"],
 "vram_texture": true
 }
 generator_parameters={}
@@ -13,7 +14,7 @@ generator_parameters={}
 [deps]
 
 source_file="res://Mods/ThrownObjects/Objects/Bastard/bastard42_baking3_Receiver top_Bake1_PBR_Normal.png"
-dest_files=["res://.godot/imported/bastard42_baking3_Receiver top_Bake1_PBR_Normal.png-e50d6323c55ab3a15397754ed4496e2d.s3tc.ctex"]
+dest_files=["res://.godot/imported/bastard42_baking3_Receiver top_Bake1_PBR_Normal.png-e50d6323c55ab3a15397754ed4496e2d.s3tc.ctex", "res://.godot/imported/bastard42_baking3_Receiver top_Bake1_PBR_Normal.png-e50d6323c55ab3a15397754ed4496e2d.etc2.ctex"]
 
 [params]
 

--- a/Mods/ThrownObjects/Objects/Bastard/bastard42_baking3_Stock_Bake1_PBR_Diffuse.png.import
+++ b/Mods/ThrownObjects/Objects/Bastard/bastard42_baking3_Stock_Bake1_PBR_Diffuse.png.import
@@ -4,8 +4,9 @@ importer="texture"
 type="CompressedTexture2D"
 uid="uid://bfkkf1ki6evvv"
 path.s3tc="res://.godot/imported/bastard42_baking3_Stock_Bake1_PBR_Diffuse.png-d615cb56dc3d53565c1f94b2d3a98336.s3tc.ctex"
+path.etc2="res://.godot/imported/bastard42_baking3_Stock_Bake1_PBR_Diffuse.png-d615cb56dc3d53565c1f94b2d3a98336.etc2.ctex"
 metadata={
-"imported_formats": ["s3tc_bptc"],
+"imported_formats": ["s3tc_bptc", "etc2_astc"],
 "vram_texture": true
 }
 generator_parameters={}
@@ -13,7 +14,7 @@ generator_parameters={}
 [deps]
 
 source_file="res://Mods/ThrownObjects/Objects/Bastard/bastard42_baking3_Stock_Bake1_PBR_Diffuse.png"
-dest_files=["res://.godot/imported/bastard42_baking3_Stock_Bake1_PBR_Diffuse.png-d615cb56dc3d53565c1f94b2d3a98336.s3tc.ctex"]
+dest_files=["res://.godot/imported/bastard42_baking3_Stock_Bake1_PBR_Diffuse.png-d615cb56dc3d53565c1f94b2d3a98336.s3tc.ctex", "res://.godot/imported/bastard42_baking3_Stock_Bake1_PBR_Diffuse.png-d615cb56dc3d53565c1f94b2d3a98336.etc2.ctex"]
 
 [params]
 

--- a/Mods/ThrownObjects/Objects/Bastard/bastard42_baking3_Stock_Bake1_PBR_Metalness-Stock_Bake1_PBR_Roughness.png.import
+++ b/Mods/ThrownObjects/Objects/Bastard/bastard42_baking3_Stock_Bake1_PBR_Metalness-Stock_Bake1_PBR_Roughness.png.import
@@ -4,8 +4,9 @@ importer="texture"
 type="CompressedTexture2D"
 uid="uid://bu8xw02bib7gt"
 path.s3tc="res://.godot/imported/bastard42_baking3_Stock_Bake1_PBR_Metalness-Stock_Bake1_PBR_Roughness.png-5057666a94cf0cbac21bde917b8396f1.s3tc.ctex"
+path.etc2="res://.godot/imported/bastard42_baking3_Stock_Bake1_PBR_Metalness-Stock_Bake1_PBR_Roughness.png-5057666a94cf0cbac21bde917b8396f1.etc2.ctex"
 metadata={
-"imported_formats": ["s3tc_bptc"],
+"imported_formats": ["s3tc_bptc", "etc2_astc"],
 "vram_texture": true
 }
 generator_parameters={}
@@ -13,7 +14,7 @@ generator_parameters={}
 [deps]
 
 source_file="res://Mods/ThrownObjects/Objects/Bastard/bastard42_baking3_Stock_Bake1_PBR_Metalness-Stock_Bake1_PBR_Roughness.png"
-dest_files=["res://.godot/imported/bastard42_baking3_Stock_Bake1_PBR_Metalness-Stock_Bake1_PBR_Roughness.png-5057666a94cf0cbac21bde917b8396f1.s3tc.ctex"]
+dest_files=["res://.godot/imported/bastard42_baking3_Stock_Bake1_PBR_Metalness-Stock_Bake1_PBR_Roughness.png-5057666a94cf0cbac21bde917b8396f1.s3tc.ctex", "res://.godot/imported/bastard42_baking3_Stock_Bake1_PBR_Metalness-Stock_Bake1_PBR_Roughness.png-5057666a94cf0cbac21bde917b8396f1.etc2.ctex"]
 
 [params]
 

--- a/Mods/ThrownObjects/Objects/Bastard/bastard42_baking3_Stock_Bake1_PBR_Normal.png.import
+++ b/Mods/ThrownObjects/Objects/Bastard/bastard42_baking3_Stock_Bake1_PBR_Normal.png.import
@@ -4,8 +4,9 @@ importer="texture"
 type="CompressedTexture2D"
 uid="uid://bvbu4f04riilb"
 path.s3tc="res://.godot/imported/bastard42_baking3_Stock_Bake1_PBR_Normal.png-a5d7fa852afebf934773b5f022625ec0.s3tc.ctex"
+path.etc2="res://.godot/imported/bastard42_baking3_Stock_Bake1_PBR_Normal.png-a5d7fa852afebf934773b5f022625ec0.etc2.ctex"
 metadata={
-"imported_formats": ["s3tc_bptc"],
+"imported_formats": ["s3tc_bptc", "etc2_astc"],
 "vram_texture": true
 }
 generator_parameters={}
@@ -13,7 +14,7 @@ generator_parameters={}
 [deps]
 
 source_file="res://Mods/ThrownObjects/Objects/Bastard/bastard42_baking3_Stock_Bake1_PBR_Normal.png"
-dest_files=["res://.godot/imported/bastard42_baking3_Stock_Bake1_PBR_Normal.png-a5d7fa852afebf934773b5f022625ec0.s3tc.ctex"]
+dest_files=["res://.godot/imported/bastard42_baking3_Stock_Bake1_PBR_Normal.png-a5d7fa852afebf934773b5f022625ec0.s3tc.ctex", "res://.godot/imported/bastard42_baking3_Stock_Bake1_PBR_Normal.png-a5d7fa852afebf934773b5f022625ec0.etc2.ctex"]
 
 [params]
 

--- a/Mods/ThrownObjects/Objects/Bit/ThrownObject_Bit_Model_ThrownObject_Bit_Texture.png.import
+++ b/Mods/ThrownObjects/Objects/Bit/ThrownObject_Bit_Model_ThrownObject_Bit_Texture.png.import
@@ -4,8 +4,9 @@ importer="texture"
 type="CompressedTexture2D"
 uid="uid://b70k30axk1ggc"
 path.s3tc="res://.godot/imported/ThrownObject_Bit_Model_ThrownObject_Bit_Texture.png-b4b2a586a045b8e3c0974d5c3947196d.s3tc.ctex"
+path.etc2="res://.godot/imported/ThrownObject_Bit_Model_ThrownObject_Bit_Texture.png-b4b2a586a045b8e3c0974d5c3947196d.etc2.ctex"
 metadata={
-"imported_formats": ["s3tc_bptc"],
+"imported_formats": ["s3tc_bptc", "etc2_astc"],
 "vram_texture": true
 }
 generator_parameters={}
@@ -13,7 +14,7 @@ generator_parameters={}
 [deps]
 
 source_file="res://Mods/ThrownObjects/Objects/Bit/ThrownObject_Bit_Model_ThrownObject_Bit_Texture.png"
-dest_files=["res://.godot/imported/ThrownObject_Bit_Model_ThrownObject_Bit_Texture.png-b4b2a586a045b8e3c0974d5c3947196d.s3tc.ctex"]
+dest_files=["res://.godot/imported/ThrownObject_Bit_Model_ThrownObject_Bit_Texture.png-b4b2a586a045b8e3c0974d5c3947196d.s3tc.ctex", "res://.godot/imported/ThrownObject_Bit_Model_ThrownObject_Bit_Texture.png-b4b2a586a045b8e3c0974d5c3947196d.etc2.ctex"]
 
 [params]
 

--- a/Mods/ThrownObjects/Objects/Bit/ThrownObject_Bit_Splat.png.import
+++ b/Mods/ThrownObjects/Objects/Bit/ThrownObject_Bit_Splat.png.import
@@ -4,15 +4,16 @@ importer="texture"
 type="CompressedTexture2D"
 uid="uid://cfwkhvhltarbp"
 path.s3tc="res://.godot/imported/ThrownObject_Bit_Splat.png-0d39018e64711b7a1398bdb77c1a1e78.s3tc.ctex"
+path.etc2="res://.godot/imported/ThrownObject_Bit_Splat.png-0d39018e64711b7a1398bdb77c1a1e78.etc2.ctex"
 metadata={
-"imported_formats": ["s3tc_bptc"],
+"imported_formats": ["s3tc_bptc", "etc2_astc"],
 "vram_texture": true
 }
 
 [deps]
 
 source_file="res://Mods/ThrownObjects/Objects/Bit/ThrownObject_Bit_Splat.png"
-dest_files=["res://.godot/imported/ThrownObject_Bit_Splat.png-0d39018e64711b7a1398bdb77c1a1e78.s3tc.ctex"]
+dest_files=["res://.godot/imported/ThrownObject_Bit_Splat.png-0d39018e64711b7a1398bdb77c1a1e78.s3tc.ctex", "res://.godot/imported/ThrownObject_Bit_Splat.png-0d39018e64711b7a1398bdb77c1a1e78.etc2.ctex"]
 
 [params]
 

--- a/Mods/ThrownObjects/Objects/GPU/GPU5_Plane-Plane.png.import
+++ b/Mods/ThrownObjects/Objects/GPU/GPU5_Plane-Plane.png.import
@@ -4,8 +4,9 @@ importer="texture"
 type="CompressedTexture2D"
 uid="uid://beattn6d84go8"
 path.s3tc="res://.godot/imported/GPU5_Plane-Plane.png-6c708c6c48fe9343ac62d101c2207175.s3tc.ctex"
+path.etc2="res://.godot/imported/GPU5_Plane-Plane.png-6c708c6c48fe9343ac62d101c2207175.etc2.ctex"
 metadata={
-"imported_formats": ["s3tc_bptc"],
+"imported_formats": ["s3tc_bptc", "etc2_astc"],
 "vram_texture": true
 }
 generator_parameters={}
@@ -13,7 +14,7 @@ generator_parameters={}
 [deps]
 
 source_file="res://Mods/ThrownObjects/Objects/GPU/GPU5_Plane-Plane.png"
-dest_files=["res://.godot/imported/GPU5_Plane-Plane.png-6c708c6c48fe9343ac62d101c2207175.s3tc.ctex"]
+dest_files=["res://.godot/imported/GPU5_Plane-Plane.png-6c708c6c48fe9343ac62d101c2207175.s3tc.ctex", "res://.godot/imported/GPU5_Plane-Plane.png-6c708c6c48fe9343ac62d101c2207175.etc2.ctex"]
 
 [params]
 

--- a/Mods/ThrownObjects/Objects/GPU/GPU5_Plane.png.import
+++ b/Mods/ThrownObjects/Objects/GPU/GPU5_Plane.png.import
@@ -4,8 +4,9 @@ importer="texture"
 type="CompressedTexture2D"
 uid="uid://thxk82mw5qq"
 path.s3tc="res://.godot/imported/GPU5_Plane.png-fef6496c09db2233a5135cf7aad06159.s3tc.ctex"
+path.etc2="res://.godot/imported/GPU5_Plane.png-fef6496c09db2233a5135cf7aad06159.etc2.ctex"
 metadata={
-"imported_formats": ["s3tc_bptc"],
+"imported_formats": ["s3tc_bptc", "etc2_astc"],
 "vram_texture": true
 }
 generator_parameters={}
@@ -13,7 +14,7 @@ generator_parameters={}
 [deps]
 
 source_file="res://Mods/ThrownObjects/Objects/GPU/GPU5_Plane.png"
-dest_files=["res://.godot/imported/GPU5_Plane.png-fef6496c09db2233a5135cf7aad06159.s3tc.ctex"]
+dest_files=["res://.godot/imported/GPU5_Plane.png-fef6496c09db2233a5135cf7aad06159.s3tc.ctex", "res://.godot/imported/GPU5_Plane.png-fef6496c09db2233a5135cf7aad06159.etc2.ctex"]
 
 [params]
 

--- a/Mods/ThrownObjects/Objects/GPU/GPU5_Plane_1.png.import
+++ b/Mods/ThrownObjects/Objects/GPU/GPU5_Plane_1.png.import
@@ -4,8 +4,9 @@ importer="texture"
 type="CompressedTexture2D"
 uid="uid://c554887dvvpos"
 path.s3tc="res://.godot/imported/GPU5_Plane_1.png-409a3669bbb144dabb1045da30d760da.s3tc.ctex"
+path.etc2="res://.godot/imported/GPU5_Plane_1.png-409a3669bbb144dabb1045da30d760da.etc2.ctex"
 metadata={
-"imported_formats": ["s3tc_bptc"],
+"imported_formats": ["s3tc_bptc", "etc2_astc"],
 "vram_texture": true
 }
 generator_parameters={}
@@ -13,7 +14,7 @@ generator_parameters={}
 [deps]
 
 source_file="res://Mods/ThrownObjects/Objects/GPU/GPU5_Plane_1.png"
-dest_files=["res://.godot/imported/GPU5_Plane_1.png-409a3669bbb144dabb1045da30d760da.s3tc.ctex"]
+dest_files=["res://.godot/imported/GPU5_Plane_1.png-409a3669bbb144dabb1045da30d760da.s3tc.ctex", "res://.godot/imported/GPU5_Plane_1.png-409a3669bbb144dabb1045da30d760da.etc2.ctex"]
 
 [params]
 

--- a/icon.svg.import
+++ b/icon.svg.import
@@ -4,15 +4,16 @@ importer="texture"
 type="CompressedTexture2D"
 uid="uid://0eiwmcispe1a"
 path.s3tc="res://.godot/imported/icon.svg-218a8f2b3041327d8a5756f3a245f83b.s3tc.ctex"
+path.etc2="res://.godot/imported/icon.svg-218a8f2b3041327d8a5756f3a245f83b.etc2.ctex"
 metadata={
-"imported_formats": ["s3tc_bptc"],
+"imported_formats": ["s3tc_bptc", "etc2_astc"],
 "vram_texture": true
 }
 
 [deps]
 
 source_file="res://icon.svg"
-dest_files=["res://.godot/imported/icon.svg-218a8f2b3041327d8a5756f3a245f83b.s3tc.ctex"]
+dest_files=["res://.godot/imported/icon.svg-218a8f2b3041327d8a5756f3a245f83b.s3tc.ctex", "res://.godot/imported/icon.svg-218a8f2b3041327d8a5756f3a245f83b.etc2.ctex"]
 
 [params]
 

--- a/project.godot
+++ b/project.godot
@@ -45,4 +45,6 @@ import/blender/enabled=false
 
 [rendering]
 
+textures/vram_compression/import_s3tc_bptc=true
+textures/vram_compression/import_etc2_astc=true
 anti_aliasing/quality/msaa_3d=2


### PR DESCRIPTION
It seems Godot by default imports textures in the format optimal for the host platform, then gets very confused if it decides it needs textures in another format for some reason (such as project export settings), and re-imports forever.

Force texture import in both main formats (ASTC, S3TC). For cross-platform collaboration, this should make sure there's no weirdness and the .import files are also universal. It's a bit slower, but pretty trivial for a projec this size.