### PR TITLE
Linux-arm64 support

### DIFF
--- a/Mods/MediaPipe/_tracker/Project/requirements.txt
+++ b/Mods/MediaPipe/_tracker/Project/requirements.txt
@@ -1,5 +1,5 @@
 mediapipe==0.10.14
-psutil==5.9.7
+psutil==6.0.0
 cv2-enumerate-cameras==1.1.10
 numpy==1.26.0
 

--- a/addons/KiriPythonRPCWrapper/KiriPythonBuildWrangler.gd
+++ b/addons/KiriPythonRPCWrapper/KiriPythonBuildWrangler.gd
@@ -311,10 +311,7 @@ func get_extra_scripts_list(platform_list : Array = []) -> Array:
 	return extra_python_files
 
 ## Get the OS name for the instance we're running.
-##
-## FIXME: Include architecture, later. Right now we're just wrapping the
-## OS.get_name() function.
 static func get_host_os_name():
-	return OS.get_name()
+	return OS.get_name() + "-" + Engine.get_architecture_name()
 
 #endregion

--- a/addons/KiriPythonRPCWrapper/UpdateUI/PythonBuildUpdateUI.gd
+++ b/addons/KiriPythonRPCWrapper/UpdateUI/PythonBuildUpdateUI.gd
@@ -356,7 +356,7 @@ func _cleanup_request():
 		_current_request = null
 
 func _on_update_button_pressed():
-	$Button_UpdateReleaseAssets.disabled = true
+	%Button_UpdateReleaseAssets.disabled = true
 	_send_github_request(
 		"https://api.github.com/repos/indygreg/python-build-standalone/releases/latest",
 		self._get_latest_version_releaseinfo_completed)

--- a/addons/KiriPythonRPCWrapper/UpdateUI/PythonBuildUpdateUI.gd
+++ b/addons/KiriPythonRPCWrapper/UpdateUI/PythonBuildUpdateUI.gd
@@ -6,6 +6,7 @@ class_name KiriPythonBuildUpdater
 # KiriPythonBuildWrangler.get_host_os_name().
 var _platform_list : Array = [
 	"Linux-x86_64",
+	"Linux-arm64",
 	"Windows-x86_64",
 	"macOS-x86_64"
 ]
@@ -481,6 +482,7 @@ func download_platform_requirements(platform_name : String, automated : bool = f
 	var platform_to_pip_mapping : Dictionary = {
 		"Windows-x86_64" : "win_amd64",
 		"Linux-x86_64" : "manylinux2014_x86_64",
+		"Linux-arm64" : "manylinux2014_aarch64",
 		"macOS-x86_64" : "macosx_11_0_universal2" # FIXME: Find something that works here. (macOS)
 	}
 

--- a/addons/KiriPythonRPCWrapper/UpdateUI/PythonBuildUpdateUI.gd
+++ b/addons/KiriPythonRPCWrapper/UpdateUI/PythonBuildUpdateUI.gd
@@ -5,9 +5,9 @@ class_name KiriPythonBuildUpdater
 # These names must match the output from
 # KiriPythonBuildWrangler.get_host_os_name().
 var _platform_list : Array = [
-	"Linux",
-	"Windows",
-	"macOS"
+	"Linux-x86_64",
+	"Windows-x86_64",
+	"macOS-x86_64"
 ]
 
 # Last processed asset list (either from cache or GitHub).
@@ -479,9 +479,9 @@ func download_platform_requirements(platform_name : String, automated : bool = f
 	# See here for platform mappings?
 	#   https://pip.pypa.io/en/stable/cli/pip_download/
 	var platform_to_pip_mapping : Dictionary = {
-		"Windows" : "win_amd64",
-		"Linux" : "manylinux2014_x86_64",
-		"macOS" : "macosx_11_0_universal2" # FIXME: Find something that works here. (macOS)
+		"Windows-x86_64" : "win_amd64",
+		"Linux-x86_64" : "manylinux2014_x86_64",
+		"macOS-x86_64" : "macosx_11_0_universal2" # FIXME: Find something that works here. (macOS)
 	}
 
 	var this_platform_download_path : String = \

--- a/addons/KiriPythonRPCWrapper/UpdateUI/PythonBuildUpdateUI.tscn
+++ b/addons/KiriPythonRPCWrapper/UpdateUI/PythonBuildUpdateUI.tscn
@@ -78,7 +78,7 @@ custom_minimum_size = Vector2(0, 256)
 layout_mode = 2
 size_flags_horizontal = 3
 text = "mediapipe==0.10.14
-psutil==5.9.7
+psutil==6.0.0
 cv2-enumerate-cameras==1.1.10
 numpy==1.26.0
 

--- a/addons/KiriPythonRPCWrapper/platform_status.json
+++ b/addons/KiriPythonRPCWrapper/platform_status.json
@@ -6,6 +6,12 @@
       "file_size": 21984711,
       "sort": "cpython-00000003-00000012-00000005-20240814-x86_64-unknown-linux-gnu-install_only_stripped-tar-gz"
     },
+    "Linux-arm64": {
+      "complete_filename": "cpython-3.12.7+20241016-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz",
+      "download_url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.12.7%2B20241016-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz",
+      "file_size": 17865102,
+      "sort": "cpython-00000003-00000012-00000007-20241016-aarch64-unknown-linux-gnu-install_only_stripped-tar-gz"
+    },
     "Windows-x86_64": {
       "complete_filename": "cpython-3.12.5+20240814-x86_64-pc-windows-msvc-shared-install_only_stripped.tar.gz",
       "download_url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-x86_64-pc-windows-msvc-shared-install_only_stripped.tar.gz",

--- a/addons/KiriPythonRPCWrapper/platform_status.json
+++ b/addons/KiriPythonRPCWrapper/platform_status.json
@@ -19,5 +19,5 @@
       "sort": "cpython-00000003-00000012-00000005-20240814-x86_64-apple-darwin-install_only_stripped-tar-gz"
     }
   },
-  "requirements": "mediapipe==0.10.14\npsutil==5.9.7\ncv2-enumerate-cameras==1.1.10\nnumpy==1.26.0\n\n"
+  "requirements": "mediapipe==0.10.14\npsutil==6.0.0\ncv2-enumerate-cameras==1.1.10\nnumpy==1.26.0\n\n"
 }

--- a/addons/KiriPythonRPCWrapper/platform_status.json
+++ b/addons/KiriPythonRPCWrapper/platform_status.json
@@ -1,18 +1,18 @@
 {
   "platforms": {
-    "Linux": {
+    "Linux-x86_64": {
       "complete_filename": "cpython-3.12.5+20240814-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz",
       "download_url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz",
       "file_size": 21984711,
       "sort": "cpython-00000003-00000012-00000005-20240814-x86_64-unknown-linux-gnu-install_only_stripped-tar-gz"
     },
-    "Windows": {
+    "Windows-x86_64": {
       "complete_filename": "cpython-3.12.5+20240814-x86_64-pc-windows-msvc-shared-install_only_stripped.tar.gz",
       "download_url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-x86_64-pc-windows-msvc-shared-install_only_stripped.tar.gz",
       "file_size": 23569213,
       "sort": "cpython-00000003-00000012-00000005-20240814-x86_64-pc-windows-msvc-shared-install_only_stripped-tar-gz"
     },
-    "macOS": {
+    "macOS-x86_64": {
       "complete_filename": "cpython-3.12.5+20240814-x86_64-apple-darwin-install_only_stripped.tar.gz",
       "download_url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-x86_64-apple-darwin-install_only_stripped.tar.gz",
       "file_size": 16564547,


### PR DESCRIPTION
Add support for Linux-arm64 (aarch64). Along the way, refactor things so the architecture is included in the OS name.

This still needs some care on macOS to figure out if we should have x86_64/aarch64 separately or together using universal binaries for everything.