### PR TITLE
fix release workflow warnings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,8 +50,7 @@ jobs:
         Build/run_this_inside_debian_container_to_build.bsh
 
     - name: Upload Assets to Release with a wildcard
-      uses: csexton/release-asset-action@v3
+      uses: shogo82148/actions-upload-release-asset@v1
       with:
-        pattern: "Build/Builds/Dist/SnekStudio_*"
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        release-url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: "Build/Builds/Dist/SnekStudio_*"
+        upload_url: ${{ steps.create_release.outputs.upload_url }}


### PR DESCRIPTION
This PR addresses the warning below:

```
Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```

The original action is no longer maintained and the backend call API it's using is deprecated. This change switches to a currently maintained action that fulfills the same need.