### PR TITLE
Don't fail on new project

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -59,6 +59,8 @@ jobs:
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         tag: nightly
+        fail-if-no-assets: false
+        fail-if-no-release: false
         assets: |
           *
 


### PR DESCRIPTION
Just noticed that I forgot a commit in my previous PR
Without this, the whole workflow fails if there is no nightly release created ... :sweat_smile:
This patch just ignores the error and makes it so that the nigthly release gets created if it doesn't exist.