### PR TITLE
Add filedialog option to lineEdit in mods

### DIFF
--- a/Core/UI/UI_Root.tscn
+++ b/Core/UI/UI_Root.tscn
@@ -108,6 +108,12 @@ file_mode = 0
 access = 2
 filters = PackedStringArray("*.vrm")
 
+[node name="LineEditFileDialog" type="FileDialog" parent="."]
+title = "Open a File"
+ok_button_text = "Open"
+file_mode = 0
+access = 2
+
 [node name="ModsWindow" parent="." instance=ExtResource("2_v48gv")]
 visible = false
 offset_left = 247.0


### PR DESCRIPTION
This is part 1 of 2 of getting custom HDRI reflections/lighting.

This adds a button for a filedialog popup, and returns the file path back to the setting. It allows for a user friendly way to obtain a file path. 

The reason why I splitted the PRs is because this might be useful even outside of the HDRI image assignment thingy. 