### PR TITLE
Add OneEuroFilter to smooth mediapipe output

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -10,6 +10,8 @@ exodrifter - https://www.exodrifter.space
 
 GenericFiredemon - https://twitch.tv/GenericFiredemon
 
+Hubble the Wolverine - https://gulo.dev
+
 Lain
 
 WileJan

--- a/Mods/MediaPipe/MediaPipeController.gd
+++ b/Mods/MediaPipe/MediaPipeController.gd
@@ -39,6 +39,7 @@ var _ikchains = []
 @export var hand_tracking_enabed : bool = true
 var use_vrm_basic_shapes = false
 var use_mediapipe_shapes = true
+var use_smoothing = true
 var frame_rate_limit = 60
 var video_device = Array() # It's an array that we only ever put one thing in.
 
@@ -91,6 +92,7 @@ func _ready():
 	add_tracked_setting("hand_tracking_enabed", "Hand tracking enabled")
 	add_tracked_setting("use_vrm_basic_shapes", "Use basic VRM shapes")
 	add_tracked_setting("use_mediapipe_shapes", "Use MediaPipe shapes")
+	add_tracked_setting("use_smoothing", "Enable smoothing")
 	add_tracked_setting("mirror_mode", "Mirror mode")
 	add_tracked_setting("frame_rate_limit", "Frame rate limit", { "min" : 1.0, "max" : 240.0 })
 	add_tracked_setting("arm_rest_angle", "Arm rest angle", { "min" : 0.0, "max" : 180.0 })
@@ -181,6 +183,9 @@ func load_after(_settings_old : Dictionary, _settings_new : Dictionary):
 		
 	tracker_python_process.call_rpc_async(
 		"set_hand_count_change_time_threshold", [hand_count_change_time_threshold])
+	
+	tracker_python_process.call_rpc_async(
+		"set_smoothing", [use_smoothing])
 
 	if _settings_old["use_external_tracker"] != _settings_new["use_external_tracker"]:
 		reset_tracker = true

--- a/Mods/MediaPipe/_tracker/Project/requirements.txt
+++ b/Mods/MediaPipe/_tracker/Project/requirements.txt
@@ -2,4 +2,4 @@ mediapipe==0.10.14
 psutil==6.0.0
 cv2-enumerate-cameras==1.1.10
 numpy==1.26.0
-
+OneEuroFilter==0.2.1

--- a/addons/KiriPythonRPCWrapper/platform_status.json
+++ b/addons/KiriPythonRPCWrapper/platform_status.json
@@ -25,5 +25,5 @@
       "sort": "cpython-00000003-00000012-00000005-20240814-x86_64-apple-darwin-install_only_stripped-tar-gz"
     }
   },
-  "requirements": "mediapipe==0.10.14\npsutil==6.0.0\ncv2-enumerate-cameras==1.1.10\nnumpy==1.26.0\n\n"
+  "requirements": "mediapipe==0.10.14\npsutil==6.0.0\ncv2-enumerate-cameras==1.1.10\nnumpy==1.26.0\nOneEuroFilter==0.2.1\n"
 }


### PR DESCRIPTION
So, I did some research for #48.

I found [1€ Filter](https://gery.casiez.net/1euro/), a realtime filter that's design to minimize jitter and lag in motion capture. I think I quite like the simplicity of it.

I think this filter is beneficial when the input camera is noisy (i.e. low light), and while the person is sitting still, which produces some amount of jitter.

Here are some example videos:

Without:
[Screencast from 2024-11-19 07-17-46.webm](https://github.com/user-attachments/assets/94286e45-75a6-45f3-a3ee-3b86b7fa5ae6)

With:
[Screencast from 2024-11-19 07-17-11.webm](https://github.com/user-attachments/assets/762b4d0e-1ac1-48a7-9b60-051345970a2f)


I also applied the filter to the blendshapes, though the effect is much less noticeable. For now, I think blendshape smoothing should be left on (without UI toggle) unless there's demand for it.

