### PR TITLE
Add reset-to-default button to each tracked setting

### DIFF
--- a/Core/UI/BasicSliderWithNumber.gd
+++ b/Core/UI/BasicSliderWithNumber.gd
@@ -35,6 +35,12 @@ func _set_value(new_value):
 	_update_widgets_with_new_values()
 	_handle_value_change(value)
 
+func set_value_no_signal(new_value):
+	_dont_handle_change_temporarily = true
+	value = new_value
+	_dont_handle_change_temporarily = false
+	_update_widgets_with_new_values()
+	
 func _set_min_value(new_min_value):
 	_dont_handle_change_temporarily = true
 	min_value = new_min_value

--- a/Core/UI/VectorSettingWidget.gd
+++ b/Core/UI/VectorSettingWidget.gd
@@ -35,6 +35,12 @@ func _set_value(new_value : Vector3):
 	_update_widgets_with_new_values()
 	_handle_value_change(value)
 
+func set_value_no_signal(new_value : Vector3):
+	_dont_handle_change_temporarily = true
+	value = new_value
+	_dont_handle_change_temporarily = false
+	_update_widgets_with_new_values()
+
 func _handle_value_change(new_value : Vector3):
 	value_changed.emit(new_value)
 


### PR DESCRIPTION
### Description

Adds a button that resets tracked settings properties to their default values.

Let me know if you feel that I should use an icon, currently it just uses the unicode icon for "undo", which at least *looks* identical to the one godot uses. I also made the button flat because it looks less bulky that way. Not entirely sure how I feel about it though. If you feel like it needs adjustment let me know and I'll change it up.

### Motivation and Context

I found myself sometimes unintentionally modifying settings (by accidentally clicking on them or otherwise), and I realized that I did not know what the default value for that setting was after I unintentionally modified it. Felt this was a pretty important thing to have some sort of solution for.

### Types of changes

- Quality of Life Feature