### PR TITLE
Fix hand smoothing defaults

### DIFF
--- a/Mods/MediaPipe/MediaPipeController.gd
+++ b/Mods/MediaPipe/MediaPipeController.gd
@@ -65,8 +65,8 @@ var tracking_pause = false
 var hand_confidence_time_threshold = 1.0
 var hand_count_change_time_threshold = 1.0
 
-var hand_rotation_smoothing : float = 1.0
-var hand_position_smoothing : float = 1.0
+var hand_rotation_smoothing : float = 2.0
+var hand_position_smoothing : float = 4.0
 var chest_yaw_scale : float = 0.25
 var lean_scale : float = 1.0
 var hip_adjustment_speed : float = 1.0


### PR DESCRIPTION
47a8f7007cfc modified hand position/rotation smoothing defaults from 4/2 to 1/1, making hands jittery by default. This changes the defaults back to what they once were, which should improve user experience for new users.

Fixes #68 