### PR TITLE
Prevent mouse wheel from modifying properties

### DIFF
--- a/Core/UI/BasicSliderWithNumber.tscn
+++ b/Core/UI/BasicSliderWithNumber.tscn
@@ -18,6 +18,7 @@ layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 1
 value = 1.0
+scrollable = false
 
 [node name="SpinBox" type="SpinBox" parent="."]
 layout_mode = 2


### PR DESCRIPTION
I found myself unintentionally modifying settings when using the mouse wheel to scroll through a properties view (particularly the MediaPipeController mod). Prevents tracked settings properties from being modified via mouse wheel. The only case this seems to happen is the HSlider in BasicSliderWithNumber.

Fixes #65