### PR TITLE
Add support for nested model skeleton

### DIFF
--- a/Core/Main.gd
+++ b/Core/Main.gd
@@ -199,7 +199,12 @@ func get_model():
 	return $ModelController.get_node_or_null("Model")
 
 func get_skeleton():
-	var skeleton = get_model().find_child("GeneralSkeleton", false, false)
+	# Skeleton may not be directly a child of the model.
+	# We also want to make sure it is actually a Skeleton3D.
+	var possible_skeletons = get_model().find_children("*", "Skeleton3D", true)
+	assert(possible_skeletons.size() >= 1)
+	
+	var skeleton = possible_skeletons[0]
 	assert(skeleton)
 	return skeleton
 


### PR DESCRIPTION
- By default for my models the skeleton is a child of an object named "Armature".
- The current code does not handle anything but a top level object named "GeneralSkeleton" so I added a type check for "Skeleton3D" instead of relying on names.
- Likely some consideration might be necessary for names, but complex checks for specific naming sequences might be expensive. I'm already not sure about using [Node.find_children()](https://docs.godotengine.org/en/stable/classes/class_node.html#class-node-method-find-children) given that this function seems to be called extensively.