### PR TITLE
Prevent mods list expanding when window resized

### DIFF
--- a/Core/UI/ModsWindow.tscn
+++ b/Core/UI/ModsWindow.tscn
@@ -11,6 +11,7 @@ label_text = "Mods"
 
 [node name="WindowTitlePanel" parent="." index="1"]
 offset_right = 563.0
+grow_horizontal = 2
 
 [node name="WindowTitle" parent="WindowTitlePanel" index="0"]
 offset_right = 531.0
@@ -26,8 +27,8 @@ grow_vertical = 2
 split_offset = -123
 
 [node name="VBoxContainer" type="VBoxContainer" parent="HSplitContainer" index="0"]
+custom_minimum_size = Vector2(200, 0)
 layout_mode = 2
-size_flags_horizontal = 3
 
 [node name="ScrollContainer" type="ScrollContainer" parent="HSplitContainer/VBoxContainer" index="0"]
 layout_mode = 2


### PR DESCRIPTION
When the mods window was resized, the mods list would also expand with it, reducing space for properties of mods unnecessarily.

This change prevents the mods listbox from expanding in order to maximize space for mod properties.