### PR TITLE
Add ability to pop out key subwindows

### DIFF
--- a/Core/Main.gd
+++ b/Core/Main.gd
@@ -10,6 +10,9 @@ var module_global_data : Dictionary = {}
 
 var _mods_loaded : bool = false
 
+# Array of all serializable BasicSubWindows
+var subwindows : Array[BasicSubWindow] = []
+
 func _process(_delta):
 	_set_process_order()
 
@@ -339,6 +342,11 @@ func serialize_settings(do_settings=true, do_mods=true):
 			mod_definition["settings"] = mod.save_settings()
 			settings_to_save["mods"].append(mod_definition)
 
+	# Save state of all serializable subwindows (dimensions/popout/etc)
+	var subwindows_dict = settings_to_save.get_or_add("subwindows", {})
+	for subwindow in subwindows:
+		subwindows_dict[subwindow.name] = subwindow._serialize_window()
+
 	return settings_to_save
 
 func _compare_values(a, b):
@@ -498,7 +506,13 @@ func deserialize_settings(settings_dict, do_settings=true, do_mods=true):
 					scene.update_settings_ui()
 			reinit_mods()
 
-
+	# Restore state of all serializable subwindows (dimensions/popout/etc)
+	var subwindows_dict = settings_dict.get("subwindows")
+	if subwindows_dict is Dictionary:
+		for subwindow in subwindows:
+			var subwindow_dict = subwindows_dict.get(subwindow.name)
+			if subwindow_dict is Dictionary:
+				subwindow._deserialize_window(subwindow_dict)
 
 func save_settings(path : String = ""):
 	

--- a/Core/Main.gd
+++ b/Core/Main.gd
@@ -152,14 +152,14 @@ func _get_ui_root():
 func _force_update_ui():
 	
 	# Update mods list.
-	_get_ui_root().get_node("ModsWindow").update_mods_list()
+	get_node("%UI_Root/%ModsWindow").update_mods_list()
 	
 	# Update settings window.
-	%UI_Root/SettingsWindow_General.settings_changed_from_app()
-	%UI_Root/SettingsWindow_Sound.settings_changed_from_app()
-	%UI_Root/SettingsWindow_Scene.settings_changed_from_app()
-	%UI_Root/SettingsWindow_Window.settings_changed_from_app()
-	%UI_Root/SettingsWindow_Colliders.update_from_app()
+	%UI_Root/%SettingsWindow_General.settings_changed_from_app()
+	%UI_Root/%SettingsWindow_Sound.settings_changed_from_app()
+	%UI_Root/%SettingsWindow_Scene.settings_changed_from_app()
+	%UI_Root/%SettingsWindow_Window.settings_changed_from_app()
+	%UI_Root/%SettingsWindow_Colliders.update_from_app()
 
 func _get_current_model_base_name():
 	var last_vrm_path = $ModelController.get_last_loaded_vrm()
@@ -651,7 +651,7 @@ func load_vrm(path) -> bool:
 
 	# FIXME: Hack to make collider visibility match collider window.
 	var ui_root = _get_ui_root()
-	var ui_collider_window = ui_root.get_node_or_null("SettingsWindow_Colliders")
+	var ui_collider_window = ui_root.get_node_or_null("%SettingsWindow_Colliders")
 	for k in collider_data:
 		k["visible"] = ui_collider_window.visible
 

--- a/Core/Main.tscn
+++ b/Core/Main.tscn
@@ -52,6 +52,7 @@ theme_override_styles/panel = SubResource("StyleBoxFlat_nh3ai")
 transform = Transform3D(1, 0, 0, 0, 0.994522, 0.104528, 0, -0.104528, 0.994522, 0, 1.45, 0)
 
 [node name="Mods" type="Node" parent="."]
+unique_name_in_owner = true
 
 [node name="ModelController" type="Node3D" parent="."]
 transform = Transform3D(1, 0, 3.49691e-07, 0, 1, 0, -3.49691e-07, 0, 1, 0, 0, 0)

--- a/Core/UI/BasicSubWindow.gd
+++ b/Core/UI/BasicSubWindow.gd
@@ -10,9 +10,15 @@ var is_size_dragging = false
 var size_dragging_vertical_edge = 0 # -1, 0, 1 for top, middle, bottom
 var size_dragging_horizontal_edge = 0 # -1, 0, 1 for left, middle, right
 
-# Serializable dimensions
+# Serializable dimensions and popout state
+var popped_out: bool = false
 var embed_window_pos: Vector2 = Vector2(0, 0)
 var embed_window_size: Vector2 = Vector2(0, 0)
+var popout_window_pos: Vector2i = Vector2i(0, 0)
+var popout_window_size: Vector2i = Vector2i(0, 0)
+
+# Native window if popped out
+var popout_window: Window = null
 
 # Position in parent.
 var _drag_start_position = position
@@ -33,10 +39,11 @@ func _ready():
 	$WindowTitlePanel/WindowTitle.text = label_text
 
 # Used to optionally add this subwindow to the list of
-# savable subwindows in SnekStudio_Main. Dimensions
-# and other state will be saved and restored.
+# savable subwindows in SnekStudio_Main. Dimensions,
+# popout, and other state will be saved and restored.
 func register_serializable_subwindow():
 	_get_app_root().subwindows.push_back(self)
+	$WindowTitlePanel/PopoutButton.show()
 
 func _process(_delta):
 	
@@ -272,13 +279,24 @@ func _on_close_button_pressed():
 
 func close_window():
 	_save_current_window_state()
-	hide()
+
+	if popped_out:
+		popout_window.hide()
+	else:
+		hide()
 
 func show_window():
 	visible = true
 	_on_resized()
 	grab_focus()
 	_on_focus_entered()
+
+	# If popped out, show popup if not visible, or grab focus and bring window to front
+	if popped_out:
+		popout_window.initial_position = Window.WINDOW_INITIAL_POSITION_ABSOLUTE
+		popout_window.position = popout_window_pos
+		popout_window.visible = true
+		popout_window.grab_focus()
 
 func _get_app_root():
 	return find_parent("SnekStudio_Main")
@@ -294,6 +312,9 @@ func serialize_window() -> Dictionary:
 func deserialize_window(dict: Dictionary) -> void:
 	pass
 
+func popout_state_changing(pop_out: bool) -> void:
+	pass
+
 #endregion
 
 # -----------------------------------------------------------------------------
@@ -306,8 +327,11 @@ func _serialize_window() -> Dictionary:
 	_save_current_window_state()
 
 	var subwindow: Dictionary = {
+		"popped_out": popped_out,
 		"embed_window_pos": [embed_window_pos.x, embed_window_pos.y],
-		"embed_window_size": [embed_window_size.x, embed_window_size.y]
+		"embed_window_size": [embed_window_size.x, embed_window_size.y],
+		"popout_window_pos": [popout_window_pos.x, popout_window_pos.y],
+		"popout_window_size": [popout_window_size.x, popout_window_size.y]
 	}
 
 	var window_settings: Dictionary = serialize_window()
@@ -318,11 +342,20 @@ func _serialize_window() -> Dictionary:
 
 # Internal deserialization called by SnekStudio_Main when loading subwindows
 func _deserialize_window(subwindow_dict: Dictionary) -> void:
-	embed_window_pos = Vector2(subwindow_dict["embed_window_pos"][0],
-							   subwindow_dict["embed_window_pos"][1])
-	embed_window_size = Vector2(subwindow_dict["embed_window_size"][0],
-								subwindow_dict["embed_window_size"][1])
-	_load_window_state()
+	var pop_out = subwindow_dict.get("popped_out")
+	if pop_out is bool:
+		embed_window_pos = Vector2(subwindow_dict["embed_window_pos"][0],
+								   subwindow_dict["embed_window_pos"][1])
+		embed_window_size = Vector2(subwindow_dict["embed_window_size"][0],
+									subwindow_dict["embed_window_size"][1])
+		popout_window_pos = Vector2i(subwindow_dict["popout_window_pos"][0],
+									 subwindow_dict["popout_window_pos"][1])
+		popout_window_size = Vector2i(subwindow_dict["popout_window_size"][0],
+									  subwindow_dict["popout_window_size"][1])
+		if pop_out != popped_out:
+			_set_popped_out(pop_out)
+		else:
+			_load_window_state(pop_out)
 
 	var settings = subwindow_dict.get("settings")
 	if settings is Dictionary:
@@ -336,11 +369,165 @@ func _deserialize_window(subwindow_dict: Dictionary) -> void:
 #region Window state
 
 func _save_current_window_state() -> void:
-	embed_window_pos = position
-	embed_window_size = size
+	if popped_out:
+		popout_window_pos = popout_window.position
+		popout_window_size = popout_window.size
+	else:
+		embed_window_pos = position
+		embed_window_size = size
 
-func _load_window_state() -> void:
-	position = embed_window_pos
-	size = embed_window_size
+func _load_window_state(pop_out: bool) -> void:
+	if pop_out:
+		popout_window.position = popout_window_pos
+		popout_window.size = popout_window_size
+	else:
+		position = embed_window_pos
+		size = embed_window_size
+
+#endregion
+
+# -----------------------------------------------------------------------------
+# Popout functionality
+
+#region Popout handling
+
+func _set_popped_out(pop_out: bool) -> void:
+	if popped_out == pop_out:
+		return
+
+	popped_out = pop_out
+
+	if pop_out:
+		# ---------------------------------------
+		# Create menu bar
+
+		var colorrect = ColorRect.new()
+		colorrect.color = Color.BLACK
+		colorrect.custom_minimum_size = Vector2(0, 32)
+
+		var hboxcontainer = HBoxContainer.new()
+		var popin_button = Button.new()
+		popin_button.text = "Pop in"
+		popin_button.focus_mode = Control.FOCUS_NONE
+		popin_button.flat = true
+		popin_button.pressed.connect(_on_popin_button_pressed)
+
+		hboxcontainer.add_child(popin_button)
+		colorrect.add_child(hboxcontainer)
+
+		# ---------------------------------------
+		# Create native window
+
+		popout_window = Window.new()
+		popout_window.title = label_text
+		popout_window.transient = true
+		popout_window.close_requested.connect(func(): close_window())
+
+		# Check to see if saved position is outside of the usable screen area.
+		# If it is, reset position and center window instead.
+		if popout_window_pos != Vector2i(0, 0) && popout_window_size != Vector2i(0, 0):
+			var inside_screen: bool = false
+
+			for screen_idx in DisplayServer.get_screen_count():
+				var screen_rect: Rect2i = DisplayServer.screen_get_usable_rect(screen_idx)
+				var tl: Vector2i = popout_window_pos
+				if screen_rect.has_point(tl):
+					inside_screen = true
+					break
+
+			if !inside_screen:
+				popout_window_pos = Vector2i(0, 0)
+
+		# Try to use the current size if it hasn't been popped out before
+		if popout_window_size == Vector2i(0, 0):
+			popout_window_size = Vector2i(size + Vector2(16, 16))
+
+		# Center window if it hasn't been popped out before
+		if popout_window_pos == Vector2i(0, 0):
+			popout_window.initial_position = Window.WINDOW_INITIAL_POSITION_CENTER_MAIN_WINDOW_SCREEN
+		else:
+			popout_window.initial_position = Window.WINDOW_INITIAL_POSITION_ABSOLUTE
+			popout_window.position = popout_window_pos
+
+		popout_window.size = popout_window_size
+		popout_window.visible = visible
+
+		# Add popout window as child of UI_Root
+		get_parent().add_child(popout_window)
+
+		# ---------------------------------------
+		# Add containers and controls to window
+
+		# Put subwindow within a control in order to get padding via anchor offsets
+		var bare_control = Control.new()
+		bare_control.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+		bare_control.size_flags_vertical = Control.SIZE_EXPAND_FILL
+
+		var container = VBoxContainer.new()
+		container.set_anchors_preset(Control.PRESET_FULL_RECT)
+		container.add_child(colorrect)
+		container.add_child(bare_control)
+
+		popout_window.add_child(container)
+
+		# ---------------------------------------
+		# Reparent to the empty control in popup window
+		#
+		# Also, always reparent last to ensure scene ownership and thus
+		# unique name access
+
+		reparent(bare_control)
+
+		# ---------------------------------------
+		# Hide embed decorations, reset dimensions, add anchors/padding
+
+		$WindowBorder.visible = false
+		$WindowTitlePanel.visible = false
+		position = Vector2(0, 0)
+		set_anchors_preset(Control.PRESET_FULL_RECT)
+		set_offset(SIDE_LEFT, 8)
+		set_offset(SIDE_TOP, 8)
+		set_offset(SIDE_BOTTOM, -8)
+		set_offset(SIDE_RIGHT, -8)
+
+	else:
+		# ---------------------------------------
+		# Restore embedded decorations and dimensions, remove anchors/padding
+
+		# Check to see if embedded position is outside of visible viewport area.
+		# If it is, reset embedded position to 0,0.
+		var ui_root = _get_app_root().get_node("%UI_Root")
+		if !Rect2(Vector2(0, 0), ui_root.size).has_point(embed_window_pos):
+			embed_window_pos = Vector2(0, 0)
+
+		$WindowBorder.visible = true
+		$WindowTitlePanel.visible = true
+		set_anchors_preset(Control.PRESET_TOP_LEFT)
+		set_offset(SIDE_LEFT, 0)
+		set_offset(SIDE_TOP, 0)
+		set_offset(SIDE_BOTTOM, 0)
+		set_offset(SIDE_RIGHT, 0)
+		position = embed_window_pos
+		size = embed_window_size
+
+		# ---------------------------------------
+		# Reparent to UI root
+
+		reparent(ui_root)
+
+		# ---------------------------------------
+		# Free popout window
+
+		popout_window.queue_free()
+
+func _on_popin_button_pressed() -> void:
+	_save_current_window_state()
+	popout_state_changing(false)
+	_set_popped_out(false)
+
+func _on_popout_button_pressed() -> void:
+	_save_current_window_state()
+	popout_state_changing(true)
+	_set_popped_out(true)
 
 #endregion

--- a/Core/UI/BasicSubWindow.gd
+++ b/Core/UI/BasicSubWindow.gd
@@ -270,5 +270,4 @@ func show_window():
 	_on_focus_entered()
 
 func _get_app_root():
-	# FIXME: DO NOT HARDCODE THIS PATH!!!!!@!@#$!@%#$^
-	return get_node("../../..")
+	return find_parent("SnekStudio_Main")

--- a/Core/UI/BasicSubWindow.tscn
+++ b/Core/UI/BasicSubWindow.tscn
@@ -51,6 +51,7 @@ layout_mode = 1
 anchors_preset = 10
 anchor_right = 1.0
 offset_top = -24.0
+grow_horizontal = 2
 theme_override_styles/panel = SubResource("StyleBoxFlat_aj8ap")
 
 [node name="WindowTitle" type="Label" parent="WindowTitlePanel"]
@@ -61,6 +62,21 @@ offset_right = 246.0
 offset_bottom = 26.0
 text = "Window"
 clip_text = true
+
+[node name="PopoutButton" type="Button" parent="WindowTitlePanel"]
+visible = false
+layout_mode = 1
+anchors_preset = 11
+anchor_left = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = -48.0
+offset_right = -24.0
+grow_horizontal = 0
+grow_vertical = 2
+focus_mode = 0
+theme_override_font_sizes/font_size = 10
+text = "p"
 
 [node name="CloseButton" type="Button" parent="WindowTitlePanel"]
 layout_mode = 1
@@ -80,4 +96,5 @@ text = "x"
 [connection signal="mouse_entered" from="WindowBorder" to="." method="_on_window_border_mouse_entered"]
 [connection signal="mouse_exited" from="WindowBorder" to="." method="_on_window_border_mouse_exited"]
 [connection signal="gui_input" from="WindowTitlePanel" to="." method="_on_window_title_panel_gui_input"]
+[connection signal="pressed" from="WindowTitlePanel/PopoutButton" to="." method="_on_popout_button_pressed"]
 [connection signal="pressed" from="WindowTitlePanel/CloseButton" to="." method="_on_close_button_pressed"]

--- a/Core/UI/ModAddWindow.gd
+++ b/Core/UI/ModAddWindow.gd
@@ -53,7 +53,7 @@ func _on_button_add_mod_pressed() -> void:
 		var mod = mod_script.instantiate()
 		_get_mods_node().add_child(mod)
 		mod.scene_init()
-		get_node("../ModsWindow").update_mods_list()
+		%ModsWindow.update_mods_list()
 
 func _on_button_cancel_pressed():
 	hide()

--- a/Core/UI/ModsWindow.gd
+++ b/Core/UI/ModsWindow.gd
@@ -2,6 +2,10 @@ extends BasicSubWindow
 
 var _selected_mod = null
 
+# Saved splitter offsets
+var embed_mod_list_offset: int = 0
+var embed_mod_status_offset: int = 0
+
 func show_window():
 	super.show_window()
 	_update_log_text()
@@ -120,6 +124,10 @@ func update_mods_list():
 	_handle_selection_change()
 
 func _ready():
+	# Save default values for splitter offsets
+	embed_mod_list_offset = $HSplitContainer.split_offset
+	embed_mod_status_offset = $HSplitContainer/VBoxContainer2/VSplitContainer.split_offset
+
 	register_serializable_subwindow()
 	update_mods_list()
 
@@ -203,3 +211,27 @@ func _on_text_edit_mod_name_gui_input(event):
 
 func _on_text_edit_mod_name_focus_exited():
 	_update_currently_selected_name()
+
+func save_current_splitter_offsets() -> void:
+	embed_mod_list_offset = $HSplitContainer.split_offset
+	embed_mod_status_offset = $HSplitContainer/VBoxContainer2/VSplitContainer.split_offset
+
+func load_splitter_offsets() -> void:
+	$HSplitContainer.split_offset = embed_mod_list_offset
+	$HSplitContainer/VBoxContainer2/VSplitContainer.split_offset = embed_mod_status_offset
+
+func serialize_window() -> Dictionary:
+	save_current_splitter_offsets()
+
+	return {"embed_mod_list_offset": embed_mod_list_offset,
+			"embed_mod_status_offset": embed_mod_status_offset}
+
+func deserialize_window(dict: Dictionary) -> void:
+	embed_mod_list_offset = dict["embed_mod_list_offset"]
+	embed_mod_status_offset = dict["embed_mod_status_offset"]
+
+	load_splitter_offsets(popped_out)
+
+func close_window() -> void:
+	save_current_splitter_offsets()
+	super.close_window()

--- a/Core/UI/ModsWindow.gd
+++ b/Core/UI/ModsWindow.gd
@@ -120,6 +120,7 @@ func update_mods_list():
 	_handle_selection_change()
 
 func _ready():
+	register_serializable_subwindow()
 	update_mods_list()
 
 func _swap_adjacent_mods(index1, index2):

--- a/Core/UI/ModsWindow.gd
+++ b/Core/UI/ModsWindow.gd
@@ -2,9 +2,11 @@ extends BasicSubWindow
 
 var _selected_mod = null
 
-# Saved splitter offsets
+# Saved splitter offsets for both embedded and popout mode
 var embed_mod_list_offset: int = 0
 var embed_mod_status_offset: int = 0
+var popout_mod_list_offset: int = 0
+var popout_mod_status_offset: int = 0
 
 func show_window():
 	super.show_window()
@@ -124,7 +126,9 @@ func update_mods_list():
 	_handle_selection_change()
 
 func _ready():
-	# Save default values for splitter offsets
+	# Save default values for both popout and embedded splitter offsets
+	popout_mod_list_offset = $HSplitContainer.split_offset
+	popout_mod_status_offset = $HSplitContainer/VBoxContainer2/VSplitContainer.split_offset
 	embed_mod_list_offset = $HSplitContainer.split_offset
 	embed_mod_status_offset = $HSplitContainer/VBoxContainer2/VSplitContainer.split_offset
 
@@ -213,22 +217,39 @@ func _on_text_edit_mod_name_focus_exited():
 	_update_currently_selected_name()
 
 func save_current_splitter_offsets() -> void:
-	embed_mod_list_offset = $HSplitContainer.split_offset
-	embed_mod_status_offset = $HSplitContainer/VBoxContainer2/VSplitContainer.split_offset
+	if popped_out:
+		popout_mod_list_offset = $HSplitContainer.split_offset
+		popout_mod_status_offset = $HSplitContainer/VBoxContainer2/VSplitContainer.split_offset
+	else:
+		embed_mod_list_offset = $HSplitContainer.split_offset
+		embed_mod_status_offset = $HSplitContainer/VBoxContainer2/VSplitContainer.split_offset
 
-func load_splitter_offsets() -> void:
-	$HSplitContainer.split_offset = embed_mod_list_offset
-	$HSplitContainer/VBoxContainer2/VSplitContainer.split_offset = embed_mod_status_offset
+func load_splitter_offsets(pop_out: bool) -> void:
+	if pop_out:
+		$HSplitContainer.split_offset = popout_mod_list_offset
+		$HSplitContainer/VBoxContainer2/VSplitContainer.split_offset = popout_mod_status_offset
+	else:
+		$HSplitContainer.split_offset = embed_mod_list_offset
+		$HSplitContainer/VBoxContainer2/VSplitContainer.split_offset = embed_mod_status_offset
+
+func popout_state_changing(pop_out: bool) -> void:
+	if pop_out != popped_out:
+		save_current_splitter_offsets()
+	load_splitter_offsets(pop_out)
 
 func serialize_window() -> Dictionary:
 	save_current_splitter_offsets()
 
-	return {"embed_mod_list_offset": embed_mod_list_offset,
+	return {"popout_mod_list_offset": popout_mod_list_offset,
+			"popout_mod_status_offset": popout_mod_status_offset,
+			"embed_mod_list_offset": embed_mod_list_offset,
 			"embed_mod_status_offset": embed_mod_status_offset}
 
 func deserialize_window(dict: Dictionary) -> void:
 	embed_mod_list_offset = dict["embed_mod_list_offset"]
 	embed_mod_status_offset = dict["embed_mod_status_offset"]
+	popout_mod_list_offset = dict["popout_mod_list_offset"]
+	popout_mod_status_offset = dict["popout_mod_status_offset"]
 
 	load_splitter_offsets(popped_out)
 

--- a/Core/UI/ModsWindow.gd
+++ b/Core/UI/ModsWindow.gd
@@ -97,8 +97,7 @@ func _on_mods_list_item_selected(_index):
 	_handle_selection_change()
 	
 func _get_mods_node():
-	# FIXME: Make a better way to get this data.
-	return get_node("../../../Mods")
+	return _get_app_root().get_node("%Mods")
 
 func update_mods_list():
 	var mods_node = _get_mods_node()

--- a/Core/UI/ModsWindow.tscn
+++ b/Core/UI/ModsWindow.tscn
@@ -103,8 +103,8 @@ text = "sdcsdasdvdfdfvsdfnvdsfmkvdfjvkmdfv
 "
 
 [node name="VBoxContainer" type="VBoxContainer" parent="HSplitContainer/VBoxContainer2/VSplitContainer" index="1"]
+custom_minimum_size = Vector2(0, 150)
 layout_mode = 2
-size_flags_vertical = 3
 
 [node name="LineEdit_ModStatus" type="LineEdit" parent="HSplitContainer/VBoxContainer2/VSplitContainer/VBoxContainer" index="0"]
 unique_name_in_owner = true

--- a/Core/UI/ModsWindow.tscn
+++ b/Core/UI/ModsWindow.tscn
@@ -11,7 +11,6 @@ label_text = "Mods"
 
 [node name="WindowTitlePanel" parent="." index="1"]
 offset_right = 563.0
-grow_horizontal = 2
 
 [node name="WindowTitle" parent="WindowTitlePanel" index="0"]
 offset_right = 531.0

--- a/Core/UI/SettingsWindow_ChannelEvents.gd
+++ b/Core/UI/SettingsWindow_ChannelEvents.gd
@@ -1,5 +1,8 @@
 extends BasicSubWindow
 
+func _ready() -> void:
+	register_serializable_subwindow()
+	super._ready()
 
 func _on_button_fake_chat_message_pressed():
 	_get_app_root()._on_handle_channel_chat_message(

--- a/Core/UI/SettingsWindow_ChannelEvents.gd
+++ b/Core/UI/SettingsWindow_ChannelEvents.gd
@@ -1,7 +1,5 @@
 extends BasicSubWindow
 
-func _get_app_root():
-	return get_node("../../..")
 
 func _on_button_fake_chat_message_pressed():
 	_get_app_root()._on_handle_channel_chat_message(

--- a/Core/UI/SettingsWindow_Colliders.gd
+++ b/Core/UI/SettingsWindow_Colliders.gd
@@ -3,9 +3,6 @@ extends BasicSubWindow
 var _tree_items_by_bone = {}
 var _root_item = null
 
-func _get_app_root():
-	return get_node("../../..")
-
 func _add_collider(collider):
 	var bone_name = collider["bone_name"]
 	if bone_name in _tree_items_by_bone:

--- a/Core/UI/SettingsWindow_Colliders.gd
+++ b/Core/UI/SettingsWindow_Colliders.gd
@@ -58,6 +58,7 @@ func _update_colliders_to_app(colliders):
 	app.set_colliders(colliders)
 
 func _ready():
+	register_serializable_subwindow()
 	_update_sliders()
 
 func _get_selected_bone():

--- a/Core/UI/SettingsWindow_General.gd
+++ b/Core/UI/SettingsWindow_General.gd
@@ -1,5 +1,8 @@
 extends BasicSubWindow
 
+func _ready() -> void:
+	register_serializable_subwindow()
+	super._ready()
 
 func settings_changed_from_app() -> void:
 	var settings : Dictionary = _get_app_root().serialize_settings(true, false)

--- a/Core/UI/SettingsWindow_General.gd
+++ b/Core/UI/SettingsWindow_General.gd
@@ -1,7 +1,5 @@
 extends BasicSubWindow
 
-func _get_app_root():
-	return get_node("../../..")
 
 func settings_changed_from_app() -> void:
 	var settings : Dictionary = _get_app_root().serialize_settings(true, false)

--- a/Core/UI/SettingsWindow_Scene.gd
+++ b/Core/UI/SettingsWindow_Scene.gd
@@ -1,5 +1,9 @@
 extends BasicSubWindow
 
+func _ready() -> void:
+	register_serializable_subwindow()
+	super._ready()
+
 func settings_changed_from_app():
 	pass
 

--- a/Core/UI/SettingsWindow_Sound.gd
+++ b/Core/UI/SettingsWindow_Sound.gd
@@ -11,6 +11,7 @@ func _input_index_selected(index):
 	update_to_app()
 
 func _ready():
+	register_serializable_subwindow()
 	%MenuButton_OutputDevice.get_popup().index_pressed.connect(_output_index_selected)
 	%MenuButton_InputDevice.get_popup().index_pressed.connect(_input_index_selected)
 

--- a/Core/UI/SettingsWindow_Window.gd
+++ b/Core/UI/SettingsWindow_Window.gd
@@ -1,5 +1,9 @@
 extends BasicSubWindow
 
+func _ready() -> void:
+	register_serializable_subwindow()
+	super._ready()
+
 func settings_changed_from_app():
 	var app = _get_app_root()
 	var settings_dict = app.serialize_settings(true, false)

--- a/Core/UI/SettingsWindow_Window.tscn
+++ b/Core/UI/SettingsWindow_Window.tscn
@@ -9,9 +9,6 @@ offset_bottom = 189.0
 script = ExtResource("2_v2kbv")
 label_text = "Window Settings"
 
-[node name="WindowTitlePanel" parent="." index="1"]
-grow_horizontal = 2
-
 [node name="WindowTitle" parent="WindowTitlePanel" index="0"]
 text = "Window Settings"
 

--- a/Core/UI/UI_Root.gd
+++ b/Core/UI/UI_Root.gd
@@ -134,21 +134,21 @@ func _on_file_id_pressed(id):
 
 func _on_settings_id_pressed(id):
 	if id == 0:
-		$SettingsWindow_General.show_window()
+		%SettingsWindow_General.show_window()
 	if id == 1:
-		$SettingsWindow_Colliders.show_window()
+		%SettingsWindow_Colliders.show_window()
 	if id == 2:
-		$SettingsWindow_Sound.show_window()
+		%SettingsWindow_Sound.show_window()
 	if id == 3:
-		$SettingsWindow_Scene.show_window()
+		%SettingsWindow_Scene.show_window()
 	if id == 4:
-		$SettingsWindow_Window.show_window()
+		%SettingsWindow_Window.show_window()
 
 func _on_mods_id_pressed(id):
 	if id == 0:
-		$ModsWindow.show_window()
+		%ModsWindow.show_window()
 	if id == 1:
-		$ChannelEvents.show_window()
+		%ChannelEvents.show_window()
 
 func _on_settings_save_dialog_file_selected(path):
 	_get_root().save_settings(path)

--- a/Core/UI/UI_Root.tscn
+++ b/Core/UI/UI_Root.tscn
@@ -143,7 +143,6 @@ offset_left = 363.0
 offset_top = 255.0
 offset_right = 641.0
 offset_bottom = 512.0
-close_button_visible = true
 
 [node name="ChannelEvents" parent="." instance=ExtResource("7_0a1sx")]
 unique_name_in_owner = true

--- a/Core/UI/UI_Root.tscn
+++ b/Core/UI/UI_Root.tscn
@@ -115,6 +115,7 @@ file_mode = 0
 access = 2
 
 [node name="ModsWindow" parent="." instance=ExtResource("2_v48gv")]
+unique_name_in_owner = true
 visible = false
 offset_left = 247.0
 offset_top = 148.0
@@ -145,6 +146,7 @@ offset_bottom = 512.0
 close_button_visible = true
 
 [node name="ChannelEvents" parent="." instance=ExtResource("7_0a1sx")]
+unique_name_in_owner = true
 visible = false
 offset_left = 664.0
 offset_top = 103.0
@@ -152,6 +154,7 @@ offset_right = 1088.0
 offset_bottom = 259.0
 
 [node name="SettingsWindow_Colliders" parent="." instance=ExtResource("2_m5fmr")]
+unique_name_in_owner = true
 visible = false
 offset_left = 308.0
 offset_top = 160.0
@@ -159,6 +162,7 @@ offset_right = 858.0
 offset_bottom = 491.0
 
 [node name="SettingsWindow_General" parent="." instance=ExtResource("4_kl5fl")]
+unique_name_in_owner = true
 visible = false
 offset_left = 281.0
 offset_top = 171.0
@@ -166,6 +170,7 @@ offset_right = 956.0
 offset_bottom = 484.0
 
 [node name="SettingsWindow_Sound" parent="." instance=ExtResource("2_22ujg")]
+unique_name_in_owner = true
 visible = false
 offset_left = 466.0
 offset_top = 225.0
@@ -173,6 +178,7 @@ offset_right = 744.0
 offset_bottom = 381.0
 
 [node name="SettingsWindow_Scene" parent="." instance=ExtResource("10_7flul")]
+unique_name_in_owner = true
 visible = false
 offset_left = 241.0
 offset_top = 206.0
@@ -180,6 +186,7 @@ offset_right = 859.0
 offset_bottom = 497.0
 
 [node name="SettingsWindow_Window" parent="." instance=ExtResource("11_5qt8l")]
+unique_name_in_owner = true
 visible = false
 offset_left = 390.0
 offset_top = 214.0

--- a/Mods/Base/Mod_Base.gd
+++ b/Mods/Base/Mod_Base.gd
@@ -326,7 +326,7 @@ func _handle_global_mod_message(key : String, values : Dictionary):
 
 func _update_log_ui(update_log = true, update_status = true):
 	# FIXME: This is a really gross way to do this thing.
-	var mods_window = get_app()._get_ui_root().get_node("ModsWindow")
+	var mods_window = get_app().get_node("%UI_Root/%ModsWindow")
 	if mods_window.visible:
 		if update_log:
 			mods_window._update_log_text_for_mod(self)

--- a/project.godot
+++ b/project.godot
@@ -32,6 +32,7 @@ settings/stdout/print_fps=true
 [display]
 
 window/size/transparent=true
+window/subwindows/embed_subwindows=false
 window/per_pixel_transparency/allowed=true
 window/vsync/vsync_mode=0
 


### PR DESCRIPTION
### Description
Adds the ability to pop out certain subwindows as native windows.

Changes included:
- The ability to pop out certain subwindows (mods/settings windows)
- An API for serializing dimensions/popout/state
- Fixes the mods log listbox expanding and taking up space unnecessarily
- Saves the current dimensions of subwindows, both when popped out and when embedded separately
- Saves/loads the offsets of the mod list and mod log vertical/horizontal splitters in the mods window

> [!NOTE]
> When embedded, the popout button is displayed to the left of the `[x]` button as a `[p]`. Because the buttons are so small, and because text is used, anything else I try feels weirdly inconsistent with the `[x]` button. I am slightly concerned that most users may not see this or realize they can pop out the window. Although this is fine for now, ideally in the future it would be nice if these buttons were a bit bigger, and had proper consistent icons.

### Motivation and Context
Overall, the motivation and context for this change is to make it so these subwindows don't necessarily have to take up valuable captured space in the main window. However you still have the choice whether to embed them or pop them out. Their popout states, dimensions, and such will be saved within the save file automatically.