### PR TITLE
KiriPythonBuildWrangler: nicer warning if mismatched archive

### DIFF
--- a/addons/KiriPythonRPCWrapper/KiriPythonBuildWrangler.gd
+++ b/addons/KiriPythonRPCWrapper/KiriPythonBuildWrangler.gd
@@ -127,6 +127,13 @@ func needs_to_unpack_python() -> bool:
 	var err : Error = reader.open(python_archive_path)
 
 	if err != OK:
+		if not DirAccess.dir_exists_absolute(python_archive_path):
+			var found_files = DirAccess.get_files_at(python_archive_path.get_base_dir())
+			var gz_files = Array(found_files).filter(func(x): return x.ends_with(".tar.gz"))
+			if gz_files.size() > 0:
+				OS.alert("Expected to find file at %s based on detected architecture '%s', your \"Python Builds\" directory has: %s"
+					% [python_archive_path, Engine.get_architecture_name(), gz_files])
+
 		OS.alert("There was a problem loading the Python archive. Did you download it in the \"Python Builds\" tab?")
 	
 	# If you hit this assert, you probably need to download the right Python


### PR DESCRIPTION
related: #92 

e.g., in case the user downloaded the arm build instead
of x86_64, this tells them what the expected path was
and what they currently have

![image](https://github.com/user-attachments/assets/c889b3ec-6927-4106-8cd9-d28794a1dc82)

Dunno if this is too verbose of an alert of it should just be printed, first time ever using godot so
am quite new to this