### PR TITLE
fix twitch integration initialization

### DIFF
--- a/Mods/Twitch/TwitchIntegration.gd
+++ b/Mods/Twitch/TwitchIntegration.gd
@@ -26,7 +26,7 @@ func scene_shutdown():
 
 func _ready() -> void:
 	var twitch : TwitchService = TwitchService.new()
-	add_child(twitch)
 	twitch.name = "TwitchService"
 	twitch.twitch_client_id = "mcelg5q6vbtp2phjxi3d5u4shb6uzh"
 	twitch.config_root = get_app().get_config_location()
+	add_child(twitch)


### PR DESCRIPTION
it was adding it to the tree, which starts oauth flow, before providing the oauth client id.