### PR TITLE
Input events propagate with UI Root open

### DIFF
--- a/Core/UI/UI_Root.gd
+++ b/Core/UI/UI_Root.gd
@@ -70,12 +70,15 @@ func _gui_input(event):
 				dragging_camera = true
 			else:
 				dragging_camera = false
+			get_viewport().set_input_as_handled()
 		
 		if event.pressed:
 			if event.button_index == MOUSE_BUTTON_WHEEL_UP:
 				camera_boom.zoom_camera(zoom_scale)
+				get_viewport().set_input_as_handled()
 			if event.button_index == MOUSE_BUTTON_WHEEL_DOWN:
 				camera_boom.zoom_camera(-zoom_scale)
+				get_viewport().set_input_as_handled()
 
 	if event is InputEventMouseMotion:
 		if dragging_camera:

--- a/Core/UI/UI_Root.tscn
+++ b/Core/UI/UI_Root.tscn
@@ -20,6 +20,7 @@ anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 size_flags_horizontal = 3
+mouse_filter = 1
 script = ExtResource("1_nc2n8")
 
 [node name="ColorRect" type="ColorRect" parent="."]


### PR DESCRIPTION
Currently, input events are completely captured by the root / main UI when it is visible, preventing you from using `_input_event` and similar with 3D nodes. This PR changes this behavior such that events are allowed to pass through, unless they are handled by the UI, including making sure that the default camera controls call `set_input_as_handled()`.