### PR TITLE
Fix various runtime warnings

### DIFF
--- a/Core/Main.gd
+++ b/Core/Main.gd
@@ -601,7 +601,6 @@ func load_vrm(path) -> bool:
 		return false
 
 	# Load colliders list
-	var model_base_name : String = _get_current_model_base_name()
 	var collider_data : Array = get_colliders(true)
 
 	# Clear "from_vrm" from everything loaded because we'll correlate

--- a/Core/ModelController.gd
+++ b/Core/ModelController.gd
@@ -83,8 +83,8 @@ func get_skeleton() -> Skeleton3D:
 	var secondary = $Model.get_node("secondary")
 	if secondary:
 		if secondary is VRMSecondary:
-			var skeleton : Skeleton3D = secondary.get_node(secondary.skeleton)
-			return skeleton
+			var skeleton2 : Skeleton3D = secondary.get_node(secondary.skeleton)
+			return skeleton2
 
 	# Buggy fallback.
 	var skeleton = get_model().find_child("GeneralSkeleton", true, false)
@@ -162,8 +162,6 @@ func reset_skeleton_to_rest_pose() -> void:
 ## Reset all the blend shapes to their neutral state.
 func reset_blend_shapes() -> void:
 	var anim_player : AnimationPlayer = $Model.find_child("AnimationPlayer", false, false)
-	var anim_list : PackedStringArray = anim_player.get_animation_list()
-	var anim_root = anim_player.get_node(anim_player.root_node)
 
 	anim_player.play("RESET")
 	anim_player.advance(0)

--- a/Core/UI/BasicSubWindow.gd
+++ b/Core/UI/BasicSubWindow.gd
@@ -70,7 +70,7 @@ func _find_child():
 
 func _on_resized() -> void:
 	var current_title_size = $WindowTitlePanel.size
-	$WindowTitlePanel.size = Vector2(size[0], current_title_size[1])
+	$WindowTitlePanel.set_deferred("size", Vector2(size[0], current_title_size[1]))
 	$WindowTitlePanel/WindowTitle.size.x = \
 		$WindowTitlePanel.size.x - \
 		2 * $WindowTitlePanel/WindowTitle.position.x
@@ -309,10 +309,10 @@ func _get_app_root():
 func serialize_window() -> Dictionary:
 	return {}
 
-func deserialize_window(dict: Dictionary) -> void:
+func deserialize_window(_dict: Dictionary) -> void:
 	pass
 
-func popout_state_changing(pop_out: bool) -> void:
+func popout_state_changing(_pop_out: bool) -> void:
 	pass
 
 #endregion

--- a/Core/UI/ModAddWindow.gd
+++ b/Core/UI/ModAddWindow.gd
@@ -58,7 +58,7 @@ func _on_button_add_mod_pressed() -> void:
 func _on_button_cancel_pressed():
 	hide()
 
-func _on_mods_list_item_selected(index: int) -> void:
+func _on_mods_list_item_selected(_index: int) -> void:
 
 	# Fill in the description field for the selection, or leave it blank if
 	# nothing is selected.

--- a/Core/UI/SettingsWindow_General.gd
+++ b/Core/UI/SettingsWindow_General.gd
@@ -22,5 +22,5 @@ func settings_changed_from_ui() -> void:
 # ------------------------------------------------------------------------------
 # Signals from various widgets indicating something has changed
 
-func _on_basic_slider_with_number_camera_fov_value_changed(value: Variant) -> void:
+func _on_basic_slider_with_number_camera_fov_value_changed(_value: Variant) -> void:
 	settings_changed_from_ui()

--- a/Mods/Base/Mod_Base.gd
+++ b/Mods/Base/Mod_Base.gd
@@ -314,7 +314,7 @@ func update_settings_ui(_ui_window = null):
 			reset_default.self_modulate = 0xFFFFFFFF * int(!is_default)
 
 ## Override to receive messages from the global mod message API.
-func _handle_global_mod_message(key : String, values : Dictionary):
+func _handle_global_mod_message(_key : String, _values : Dictionary):
 	return
 
 #endregion
@@ -485,9 +485,9 @@ func settings_window_add_boolean(setting_label, setting_name) -> Control:
 	var default_value = get(setting_name)
 
 	var reset_default = Button.new()
-	var reset_default_action = func(default_value):
-		modify_setting(setting_name, default_value)
-		checkbox_widget.set_pressed_no_signal(default_value)
+	var reset_default_action = func(val):
+		modify_setting(setting_name, val)
+		checkbox_widget.set_pressed_no_signal(val)
 	reset_default.text = defaults_text_get_rid_of_me
 	reset_default.flat = true
 	reset_default.pressed.connect(
@@ -532,9 +532,9 @@ func settings_window_add_spinbox(
 	var default_value = get(setting_name)
 	
 	var reset_default = Button.new()
-	var reset_default_action = func(default_value):
-		modify_setting(setting_name, default_value)
-		spinbox_widget.set_value_no_signal(default_value)
+	var reset_default_action = func(val):
+		modify_setting(setting_name, val)
+		spinbox_widget.set_value_no_signal(val)
 	reset_default.text = defaults_text_get_rid_of_me
 	reset_default.flat = true
 	reset_default.disabled = true
@@ -606,9 +606,9 @@ func settings_window_add_lineedit(
 	var default_value = get(setting_name)
 	
 	var reset_default = Button.new()
-	var reset_default_action = func(default_value):
-		modify_setting(setting_name, default_value)
-		lineedit_widget.set_text(default_value)
+	var reset_default_action = func(val):
+		modify_setting(setting_name, val)
+		lineedit_widget.set_text(val)
 	reset_default.text = defaults_text_get_rid_of_me
 	reset_default.flat = true
 	reset_default.pressed.connect(
@@ -658,9 +658,9 @@ func settings_window_add_slider_with_number(
 	default_value = roundf((default_value - min_value) / step) * step + min_value
 	
 	var reset_default = Button.new()
-	var reset_default_action = func(default_value):
-		modify_setting(setting_name, default_value)
-		slider_widget.set_value_no_signal(default_value)
+	var reset_default_action = func(val):
+		modify_setting(setting_name, val)
+		slider_widget.set_value_no_signal(val)
 	reset_default.text = defaults_text_get_rid_of_me
 	reset_default.flat = true
 	reset_default.pressed.connect(
@@ -730,9 +730,9 @@ func settings_window_add_selector(
 		selection_widget.text_overrun_behavior = TextServer.OVERRUN_TRIM_ELLIPSIS
 		selection_widget.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 		
-		reset_default_action = func(default_value):
-			modify_setting(setting_name, default_value)
-			for value in default_value:
+		reset_default_action = func(val):
+			modify_setting(setting_name, val)
+			for value in val:
 				for idx in selection_widget.item_count:
 					if selection_widget.get_item_text(idx) == value:
 						selection_widget.select(idx)
@@ -745,12 +745,12 @@ func settings_window_add_selector(
 		if allow_multiple:
 			selection_widget.select_mode = ItemList.SELECT_MULTI
 		
-		reset_default_action = func(default_value):
+		reset_default_action = func(val):
 			var single = selection_widget.select_mode != ItemList.SELECT_MULTI
-			modify_setting(setting_name, default_value)
+			modify_setting(setting_name, val)
 			if !single:
 				selection_widget.deselect_all()
-			for value in default_value:
+			for value in val:
 				for idx in selection_widget.item_count:
 					if selection_widget.get_item_text(idx) == value:
 						selection_widget.select(idx, single)
@@ -798,9 +798,9 @@ func settings_window_add_colorpicker(
 	var default_value = get(setting_name)
 	
 	var reset_default = Button.new()
-	var reset_default_action = func(default_value):
-		modify_setting(setting_name, default_value)
-		colorpicker_widget.set_pick_color(default_value)
+	var reset_default_action = func(val):
+		modify_setting(setting_name, val)
+		colorpicker_widget.set_pick_color(val)
 	reset_default.text = defaults_text_get_rid_of_me
 	reset_default.flat = true
 	reset_default.pressed.connect(
@@ -847,9 +847,9 @@ func settings_window_add_vector3(
 	var default_value = get(setting_name)
 	
 	var reset_default = Button.new()
-	var reset_default_action = func(default_value):
-		modify_setting(setting_name, default_value)
-		vec3_widget.set_value_no_signal(default_value)
+	var reset_default_action = func(val):
+		modify_setting(setting_name, val)
+		vec3_widget.set_value_no_signal(val)
 	reset_default.text = defaults_text_get_rid_of_me
 	reset_default.flat = true
 	reset_default.pressed.connect(

--- a/Mods/MediaPipe/MediaPipeController.gd
+++ b/Mods/MediaPipe/MediaPipeController.gd
@@ -715,7 +715,6 @@ func _setup_ik_chains():
 			
 			# Keep looking and see if we can find something beyond the most
 			# distant bone.
-			var search_past_finger_tips_for_bones : bool = true
 			while true:
 				var child_bones : PackedInt32Array = chain_finger.skeleton.get_bone_children(
 					chain_finger.skeleton.find_bone(chain_finger.tip_bone))
@@ -892,7 +891,6 @@ func mirror_parsed_data(parsed_data : Dictionary) -> Dictionary:
 	# Now, swap the values.
 	for hand_name in [ "left", "right" ]:
 		
-		var hand_score_str = "hand_" + hand_name + "_score"
 		var hand_rotation_str = "hand_" + hand_name + "_rotation"
 		var hand_origin_str = "hand_" + hand_name + "_origin"
 		var hand_landmark_str = "hand_landmarks_" + hand_name 


### PR DESCRIPTION
### Description

Fixes approximately 24 runtime warnings.

### Motivation and Context

Just noticed various warnings, some of which I introduced, some of which were already there. I figured I'd get rid of them.

> [!NOTE]
>
> This leaves one warning behind as of this commit, but it's mostly because there's a fair amount of code after a return statement and I'm unsure if it's intended to leave that code

### Types of Changed

- Code cleanup