### PR TITLE
Make "Add Mod" window bigger

### DIFF
--- a/Core/UI/UI_Root.tscn
+++ b/Core/UI/UI_Root.tscn
@@ -144,8 +144,8 @@ focus_mode = 0
 visible = false
 offset_left = 363.0
 offset_top = 255.0
-offset_right = 641.0
-offset_bottom = 512.0
+offset_right = 841.0
+offset_bottom = 612.0
 
 [node name="ChannelEvents" parent="." instance=ExtResource("7_0a1sx")]
 unique_name_in_owner = true


### PR DESCRIPTION
### Description

The default size of the "Add Mod" window was a bit small. This increases the default size to make the list and description text a bit less squimshed.

### Motivation and Context

The squimshed window for mod selection/description was a bit awkward when adding a mod.

### Types of Changes

- Tweak (non-breaking change to improve existing functionality)