### PR TITLE
Fix window moving down when popping in

### DIFF
--- a/Core/UI/BasicSubWindow.gd
+++ b/Core/UI/BasicSubWindow.gd
@@ -507,13 +507,15 @@ func _set_popped_out(pop_out: bool) -> void:
 		set_offset(SIDE_TOP, 0)
 		set_offset(SIDE_BOTTOM, 0)
 		set_offset(SIDE_RIGHT, 0)
-		position = embed_window_pos
-		size = embed_window_size
 
 		# ---------------------------------------
 		# Reparent to UI root
 
 		reparent(ui_root)
+
+		if embed_window_pos != Vector2(0, 0) && embed_window_size != Vector2(0, 0):
+			position = embed_window_pos
+			size = embed_window_size
 
 		# ---------------------------------------
 		# Free popout window


### PR DESCRIPTION
### Description

When popping a window back in after it's been popped out, the reparent() call will cause the window to reposition relative to its parent, which causes the embedded version of a window to move down a bit, so if you don't want the position of a window to be modified, you have to set the window position/size *after* the reparent() call. Learned this after debugging into the engine code itself.

### Types of Changes
- Tweak (non-breaking change to improve existing functionality)