### PR TITLE
Make Add Mod window usable while Mods window popped out

### DIFF
--- a/Core/UI/BasicSubWindow.gd
+++ b/Core/UI/BasicSubWindow.gd
@@ -16,6 +16,7 @@ var embed_window_pos: Vector2 = Vector2(0, 0)
 var embed_window_size: Vector2 = Vector2(0, 0)
 var popout_window_pos: Vector2i = Vector2i(0, 0)
 var popout_window_size: Vector2i = Vector2i(0, 0)
+var popout_modal: bool = false
 
 # Native window if popped out
 var popout_window: Window = null
@@ -398,22 +399,25 @@ func _set_popped_out(pop_out: bool) -> void:
 	popped_out = pop_out
 
 	if pop_out:
+		var colorrect: ColorRect = null
+
 		# ---------------------------------------
 		# Create menu bar
 
-		var colorrect = ColorRect.new()
-		colorrect.color = Color.BLACK
-		colorrect.custom_minimum_size = Vector2(0, 32)
+		if !popout_modal:
+			colorrect = ColorRect.new()
+			colorrect.color = Color.BLACK
+			colorrect.custom_minimum_size = Vector2(0, 32)
 
-		var hboxcontainer = HBoxContainer.new()
-		var popin_button = Button.new()
-		popin_button.text = "Pop in"
-		popin_button.focus_mode = Control.FOCUS_NONE
-		popin_button.flat = true
-		popin_button.pressed.connect(_on_popin_button_pressed)
+			var hboxcontainer = HBoxContainer.new()
+			var popin_button = Button.new()
+			popin_button.text = "Pop in"
+			popin_button.focus_mode = Control.FOCUS_NONE
+			popin_button.flat = true
+			popin_button.pressed.connect(_on_popin_button_pressed)
 
-		hboxcontainer.add_child(popin_button)
-		colorrect.add_child(hboxcontainer)
+			hboxcontainer.add_child(popin_button)
+			colorrect.add_child(hboxcontainer)
 
 		# ---------------------------------------
 		# Create native window
@@ -465,7 +469,8 @@ func _set_popped_out(pop_out: bool) -> void:
 
 		var container = VBoxContainer.new()
 		container.set_anchors_preset(Control.PRESET_FULL_RECT)
-		container.add_child(colorrect)
+		if colorrect != null:
+			container.add_child(colorrect)
 		container.add_child(bare_control)
 
 		popout_window.add_child(container)

--- a/Core/UI/ModAddWindow.gd
+++ b/Core/UI/ModAddWindow.gd
@@ -4,7 +4,7 @@ var _mods_list = []
 
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
-
+	popout_modal = true
 	_get_app_root()._load_mods()
 
 	var mod_scene_files : PackedStringArray
@@ -42,8 +42,7 @@ func _ready() -> void:
 		%Mods_List.add_item(mod_entry["name"])
 
 func _get_mods_node():
-	# FIXME: Make a better way to get this data.
-	return get_node("../../../Mods")
+	return _get_app_root().get_node("%Mods")
 
 func _on_button_add_mod_pressed() -> void:
 
@@ -56,7 +55,7 @@ func _on_button_add_mod_pressed() -> void:
 		%ModsWindow.update_mods_list()
 
 func _on_button_cancel_pressed():
-	hide()
+	close_window()
 
 func _on_mods_list_item_selected(index: int) -> void:
 

--- a/Core/UI/ModsWindow.gd
+++ b/Core/UI/ModsWindow.gd
@@ -191,8 +191,15 @@ func _on_button_remove_mod_pressed():
 	update_mods_list()
 
 func _on_button_add_mod_pressed():
-	get_node("../ModAddWindow").show_window()
-
+	var add_window = _get_app_root().get_node("%UI_Root/%ModAddWindow")
+	add_window._save_current_window_state()
+	add_window.show_window()
+	add_window._set_popped_out(popped_out)
+	if popped_out:
+		var last_owner = add_window.owner
+		add_window.popout_window.reparent(self)
+		add_window.owner = last_owner
+		add_window.popout_window.exclusive = true
 
 func _update_currently_selected_name():
 	var mods_list_node : ItemList = %ModsList

--- a/Core/UI/UI_Root.tscn
+++ b/Core/UI/UI_Root.tscn
@@ -45,6 +45,7 @@ title = "acsdcscsc"
 size = Vector2i(145, 124)
 item_count = 6
 item_0/text = "Open VRM..."
+item_0/id = 0
 item_1/id = 5
 item_1/separator = true
 item_2/text = "Save settings..."
@@ -60,6 +61,7 @@ item_5/id = 1
 size = Vector2i(176, 100)
 item_count = 5
 item_0/text = "General settings..."
+item_0/id = 0
 item_1/text = "Colliders..."
 item_1/id = 1
 item_2/text = "Sound..."
@@ -72,6 +74,7 @@ item_4/id = 4
 [node name="Modules" type="PopupMenu" parent="ColorRect/HBoxContainer/MenuBar"]
 item_count = 2
 item_0/text = "Mod list..."
+item_0/id = 0
 item_1/text = "Channel Event Tester..."
 item_1/id = 1
 
@@ -85,6 +88,7 @@ layout_mode = 2
 [node name="Help" type="PopupMenu" parent="ColorRect/HBoxContainer/MenuBar2"]
 item_count = 2
 item_0/text = "Controls..."
+item_0/id = 0
 item_1/text = "About..."
 item_1/id = 1
 
@@ -141,6 +145,7 @@ offset_bottom = 384.0
 focus_mode = 0
 
 [node name="ModAddWindow" parent="." instance=ExtResource("6_ohgoj")]
+unique_name_in_owner = true
 visible = false
 offset_left = 363.0
 offset_top = 255.0


### PR DESCRIPTION
### Description

Makes the Add Mod window actually usable while the Mods window is popped out in its own window.

### Motivation and Context

There were a number of issues with the Add Mod window when the Mods window was popped out:
- It would crash due to reliance on relative path node lookup (the Add Mod window now uses a unique scene identifier)
- The Add Mod window could go behind the main window or behind the Mod window (it's now modal when popped out)
- The Add Mod window should probably not able to individually be popped back in (removed the Popin option for the Add Mod window when the Mod window is popped out)

### Types of Changes

- Bug fix (non-breaking change which fixes an issue)
- Tweak (non-breaking change to improve existing functionality)