### PR TITLE
Create settings directory if it doesn't exist

### DIFF
--- a/Core/Main.gd
+++ b/Core/Main.gd
@@ -523,6 +523,13 @@ func save_settings(path : String = ""):
 	if settings_filename == "":
 		settings_filename = _get_default_settings_path()
 	
+	# Create settings directory if it doesn't already exist
+	var settings_dir = ProjectSettings.globalize_path(settings_filename.get_basename())
+	if not DirAccess.dir_exists_absolute(settings_dir):
+		if DirAccess.make_dir_recursive_absolute(settings_dir) != OK:
+			push_error("Failed to create settings directory: " + settings_dir)
+			return
+	
 	# Convert settings to JSON and save.
 	var save_string = JSON.stringify(settings_to_save, "  ")
 	var file = FileAccess.open(settings_filename, FileAccess.WRITE)


### PR DESCRIPTION
Fixes an issue in `Main.save_settings()` where, if the settings directory doesn't already exist, settings don't actually persist when closing the application normally. Especially noticeable when using `SNEKSTUDIO_CONFIG_PATH`. Such a check doesn't appear to be necessary for `SNEKSTUDIO_CACHE_PATH` – it is created just fine.