### PR TITLE
Feature/macos aarch64

### DIFF
--- a/Build/DownloadPythonRequirements.gd
+++ b/Build/DownloadPythonRequirements.gd
@@ -22,7 +22,8 @@ func _process(_delta):
 		updater._start_github_download("Windows-x86_64")
 		updater._start_github_download("Linux-x86_64")
 		updater._start_github_download("Linux-arm64")
-		# FIXME: MacOS.
+		updater._start_github_download("macOS-arm64")
+		# FIXME: MacOS x86_64
 
 		for platform in updater._current_downloads.keys():
 			var download_request : HTTPRequest = updater._current_downloads[platform]

--- a/Mods/MediaPipe/_tracker/Project/requirements.txt
+++ b/Mods/MediaPipe/_tracker/Project/requirements.txt
@@ -1,5 +1,5 @@
-mediapipe==0.10.14
-psutil==6.0.0
-cv2-enumerate-cameras==1.1.18.2
-numpy==1.26.0
+mediapipe==0.10.21
+psutil==7.0.0
+cv2-enumerate-cameras==1.1.18.3
+numpy==1.26.4
 

--- a/Tests/Python/test_python_rpc.gd
+++ b/Tests/Python/test_python_rpc.gd
@@ -24,7 +24,7 @@ func _ready() -> void:
 	tracker_python_process.start_process()
 	
 	print("Kicking off thing...")
-	var r = await tracker_python_process.execute_python_async(["-m", "pip", "install", "mediapipe==0.10.14"])
+	var r = await tracker_python_process.execute_python_async(["-m", "pip", "install", "mediapipe==0.10.21"])
 	print("Done thing: ", r)
 	
 

--- a/addons/KiriPythonRPCWrapper/KiriPythonBuildWrangler.gd
+++ b/addons/KiriPythonRPCWrapper/KiriPythonBuildWrangler.gd
@@ -201,13 +201,17 @@ func unpack_python():
 
 	# Detect Python executable.
 	var possible_executable_paths = []
-	if OS.get_name() == "Windows":
-		possible_executable_paths.append("python/install/python.exe")
-		possible_executable_paths.append("python/python.exe")
-	else:
-		possible_executable_paths.append("python/bin/python")
-		possible_executable_paths.append("python/install/bin/python")
-		# FIXME: Verify that these are the same in macOS.
+	match OS.get_name():
+		"Windows":
+			possible_executable_paths.append("python/install/python.exe")
+			possible_executable_paths.append("python/python.exe")
+		"macOS":
+			possible_executable_paths.append("python/bin/python")
+			possible_executable_paths.append("python/install/bin/python")
+		_:
+			possible_executable_paths.append("python/bin/python")
+			possible_executable_paths.append("python/install/bin/python")
+
 	for possible_path in possible_executable_paths:
 		if FileAccess.file_exists(cache_path_godot.path_join(possible_path)):
 			cache_status["executable_path"] = possible_path

--- a/addons/KiriPythonRPCWrapper/UpdateUI/PythonBuildUpdateUI.tscn
+++ b/addons/KiriPythonRPCWrapper/UpdateUI/PythonBuildUpdateUI.tscn
@@ -77,8 +77,7 @@ unique_name_in_owner = true
 custom_minimum_size = Vector2(0, 256)
 layout_mode = 2
 size_flags_horizontal = 3
-text = "
-mediapipe==0.10.21
+text = "mediapipe==0.10.21
 psutil==7.0.0
 cv2-enumerate-cameras==1.1.18.3
 numpy==1.26.4

--- a/addons/KiriPythonRPCWrapper/UpdateUI/PythonBuildUpdateUI.tscn
+++ b/addons/KiriPythonRPCWrapper/UpdateUI/PythonBuildUpdateUI.tscn
@@ -77,10 +77,11 @@ unique_name_in_owner = true
 custom_minimum_size = Vector2(0, 256)
 layout_mode = 2
 size_flags_horizontal = 3
-text = "mediapipe==0.10.14
-psutil==6.0.0
-cv2-enumerate-cameras==1.1.18.2
-numpy==1.26.0
+text = "
+mediapipe==0.10.21
+psutil==7.0.0
+cv2-enumerate-cameras==1.1.18.3
+numpy==1.26.4
 
 "
 gutters_draw_line_numbers = true

--- a/addons/KiriPythonRPCWrapper/platform_status.json
+++ b/addons/KiriPythonRPCWrapper/platform_status.json
@@ -1,29 +1,35 @@
 {
   "platforms": {
-    "Linux-arm64": {
-      "complete_filename": "cpython-3.12.7+20241016-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz",
-      "download_url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.12.7%2B20241016-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz",
-      "file_size": 17865102,
-      "sort": "cpython-00000003-00000012-00000007-20241016-aarch64-unknown-linux-gnu-install_only_stripped-tar-gz"
-    },
-    "Linux-x86_64": {
-      "complete_filename": "cpython-3.12.5+20240814-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz",
-      "download_url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz",
-      "file_size": 21984711,
-      "sort": "cpython-00000003-00000012-00000005-20240814-x86_64-unknown-linux-gnu-install_only_stripped-tar-gz"
-    },
-    "Windows-x86_64": {
-      "complete_filename": "cpython-3.12.5+20240814-x86_64-pc-windows-msvc-shared-install_only_stripped.tar.gz",
-      "download_url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-x86_64-pc-windows-msvc-shared-install_only_stripped.tar.gz",
-      "file_size": 23569213,
-      "sort": "cpython-00000003-00000012-00000005-20240814-x86_64-pc-windows-msvc-shared-install_only_stripped-tar-gz"
-    },
-    "macOS-x86_64": {
-      "complete_filename": "cpython-3.12.5+20240814-x86_64-apple-darwin-install_only_stripped.tar.gz",
-      "download_url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-x86_64-apple-darwin-install_only_stripped.tar.gz",
-      "file_size": 16564547,
-      "sort": "cpython-00000003-00000012-00000005-20240814-x86_64-apple-darwin-install_only_stripped-tar-gz"
-    }
+	"Linux-arm64": {
+	  "complete_filename": "cpython-3.12.7+20241016-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz",
+	  "download_url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.12.7%2B20241016-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz",
+	  "file_size": 17865102,
+	  "sort": "cpython-00000003-00000012-00000007-20241016-aarch64-unknown-linux-gnu-install_only_stripped-tar-gz"
+	},
+	"Linux-x86_64": {
+	  "complete_filename": "cpython-3.12.5+20240814-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz",
+	  "download_url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz",
+	  "file_size": 21984711,
+	  "sort": "cpython-00000003-00000012-00000005-20240814-x86_64-unknown-linux-gnu-install_only_stripped-tar-gz"
+	},
+	"Windows-x86_64": {
+	  "complete_filename": "cpython-3.12.5+20240814-x86_64-pc-windows-msvc-shared-install_only_stripped.tar.gz",
+	  "download_url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-x86_64-pc-windows-msvc-shared-install_only_stripped.tar.gz",
+	  "file_size": 23569213,
+	  "sort": "cpython-00000003-00000012-00000005-20240814-x86_64-pc-windows-msvc-shared-install_only_stripped-tar-gz"
+	},
+	"macOS-x86_64": {
+	  "complete_filename": "cpython-3.12.5+20240814-x86_64-apple-darwin-install_only_stripped.tar.gz",
+	  "download_url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-x86_64-apple-darwin-install_only_stripped.tar.gz",
+	  "file_size": 16564547,
+	  "sort": "cpython-00000003-00000012-00000005-20240814-x86_64-apple-darwin-install_only_stripped-tar-gz"
+	},
+	"macOS-arm64": {
+	  "complete_filename": "cpython-3.12.5+20240814-aarch64-apple-darwin-install_only_stripped.tar.gz",
+	  "download_url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-aarch64-apple-darwin-install_only_stripped.tar.gz",
+	  "file_size": 16223961,
+	  "sort": "cpython-00000003-00000012-00000005-20240814-aarch64-apple-darwin-install_only_stripped-tar-gz"
+	}
   },
   "requirements": "mediapipe==0.10.21\npsutil==7.0.0\ncv2-enumerate-cameras==1.1.18.3\nnumpy==1.26.4\n\n"
 }

--- a/addons/KiriPythonRPCWrapper/platform_status.json
+++ b/addons/KiriPythonRPCWrapper/platform_status.json
@@ -25,5 +25,5 @@
       "sort": "cpython-00000003-00000012-00000005-20240814-x86_64-apple-darwin-install_only_stripped-tar-gz"
     }
   },
-  "requirements": "mediapipe==0.10.14\npsutil==6.0.0\ncv2-enumerate-cameras==1.1.18.2\nnumpy==1.26.0\n\n"
+  "requirements": "mediapipe==0.10.21\npsutil==7.0.0\ncv2-enumerate-cameras==1.1.18.3\nnumpy==1.26.4\n\n"
 }

--- a/addons/KiriPythonRPCWrapper/platform_status.json
+++ b/addons/KiriPythonRPCWrapper/platform_status.json
@@ -1,35 +1,35 @@
 {
   "platforms": {
-	"Linux-arm64": {
-	  "complete_filename": "cpython-3.12.7+20241016-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz",
-	  "download_url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.12.7%2B20241016-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz",
-	  "file_size": 17865102,
-	  "sort": "cpython-00000003-00000012-00000007-20241016-aarch64-unknown-linux-gnu-install_only_stripped-tar-gz"
-	},
-	"Linux-x86_64": {
-	  "complete_filename": "cpython-3.12.5+20240814-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz",
-	  "download_url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz",
-	  "file_size": 21984711,
-	  "sort": "cpython-00000003-00000012-00000005-20240814-x86_64-unknown-linux-gnu-install_only_stripped-tar-gz"
-	},
-	"Windows-x86_64": {
-	  "complete_filename": "cpython-3.12.5+20240814-x86_64-pc-windows-msvc-shared-install_only_stripped.tar.gz",
-	  "download_url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-x86_64-pc-windows-msvc-shared-install_only_stripped.tar.gz",
-	  "file_size": 23569213,
-	  "sort": "cpython-00000003-00000012-00000005-20240814-x86_64-pc-windows-msvc-shared-install_only_stripped-tar-gz"
-	},
-	"macOS-x86_64": {
-	  "complete_filename": "cpython-3.12.5+20240814-x86_64-apple-darwin-install_only_stripped.tar.gz",
-	  "download_url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-x86_64-apple-darwin-install_only_stripped.tar.gz",
-	  "file_size": 16564547,
-	  "sort": "cpython-00000003-00000012-00000005-20240814-x86_64-apple-darwin-install_only_stripped-tar-gz"
-	},
-	"macOS-arm64": {
-	  "complete_filename": "cpython-3.12.5+20240814-aarch64-apple-darwin-install_only_stripped.tar.gz",
-	  "download_url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-aarch64-apple-darwin-install_only_stripped.tar.gz",
-	  "file_size": 16223961,
-	  "sort": "cpython-00000003-00000012-00000005-20240814-aarch64-apple-darwin-install_only_stripped-tar-gz"
-	}
+    "Linux-arm64": {
+      "complete_filename": "cpython-3.12.7+20241016-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz",
+      "download_url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.12.7%2B20241016-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz",
+      "file_size": 17865102,
+      "sort": "cpython-00000003-00000012-00000007-20241016-aarch64-unknown-linux-gnu-install_only_stripped-tar-gz"
+    },
+    "Linux-x86_64": {
+      "complete_filename": "cpython-3.12.5+20240814-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz",
+      "download_url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz",
+      "file_size": 21984711,
+      "sort": "cpython-00000003-00000012-00000005-20240814-x86_64-unknown-linux-gnu-install_only_stripped-tar-gz"
+    },
+    "Windows-x86_64": {
+      "complete_filename": "cpython-3.12.5+20240814-x86_64-pc-windows-msvc-shared-install_only_stripped.tar.gz",
+      "download_url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-x86_64-pc-windows-msvc-shared-install_only_stripped.tar.gz",
+      "file_size": 23569213,
+      "sort": "cpython-00000003-00000012-00000005-20240814-x86_64-pc-windows-msvc-shared-install_only_stripped-tar-gz"
+    },
+    "macOS-x86_64": {
+      "complete_filename": "cpython-3.12.5+20240814-x86_64-apple-darwin-install_only_stripped.tar.gz",
+      "download_url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-x86_64-apple-darwin-install_only_stripped.tar.gz",
+      "file_size": 16564547,
+      "sort": "cpython-00000003-00000012-00000005-20240814-x86_64-apple-darwin-install_only_stripped-tar-gz"
+    },
+    "macOS-arm64": {
+      "complete_filename": "cpython-3.12.5+20240814-aarch64-apple-darwin-install_only_stripped.tar.gz",
+      "download_url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-aarch64-apple-darwin-install_only_stripped.tar.gz",
+      "file_size": 16223961,
+      "sort": "cpython-00000003-00000012-00000005-20240814-aarch64-apple-darwin-install_only_stripped-tar-gz"
+    }
   },
   "requirements": "mediapipe==0.10.21\npsutil==7.0.0\ncv2-enumerate-cameras==1.1.18.3\nnumpy==1.26.4\n\n"
 }


### PR DESCRIPTION
# Support for macos aarch64 (Mac ARM 64 systems)

<img width="1032" alt="image" src="https://github.com/user-attachments/assets/d51e3400-a8ad-42cb-8437-dc87d0e4d203" />

Also an update for other users to see that download mac deps outside of a mac arm computer is not supported - that way people aren't confused when they get a massive pip download error.