### PR TITLE
Fix: Tracking disabled due to IK processing skipped

### DIFF
--- a/Mods/MediaPipe/MediaPipeController.gd
+++ b/Mods/MediaPipe/MediaPipeController.gd
@@ -1214,8 +1214,6 @@ func _process(delta):
 	if delta_scale < 0.01:
 		delta_scale = 0.01
 
-	return
-
 	if last_parsed_data:
 		var parsed_data = last_parsed_data
 
@@ -1455,8 +1453,6 @@ func _process(delta):
 
 		# Arm IK.
 		
-		return
-
 		var x_pole_dist = 10.0
 		var z_pole_dist = 10.0
 		var y_pole_dist = 5.0


### PR DESCRIPTION
Related issue: #116

Slight issue with the tracking being disabled on main branch due to some return statements in the process function of MediaPipeController.

These were introduced in this commit #https://github.com/ExpiredPopsicle/SnekStudio/commit/5033b8c181f720f17f5247f6bf669110ee935520

Reverting these changes makes model tracking work again.