### PR TITLE
added head pitch offset

### DIFF
--- a/Mods/MediaPipe/MediaPipeController.gd
+++ b/Mods/MediaPipe/MediaPipeController.gd
@@ -22,6 +22,7 @@ var _init_complete = false
 var frames_missing_before_spine_reset = 6.0
 var blend_to_rest_speed = 4.5
 var head_vertical_offset : float = -0.2
+var head_pitch_offset: float = 0.0
 var hips_vertical_blend_speed : float = 6.0
 
 
@@ -324,6 +325,10 @@ func _ready():
 
 	add_tracked_setting(
 		"head_vertical_offset", "Head vertical offset",
+		{ "min" : -1.0, "max" : 1.0 },
+		"advanced")
+	add_tracked_setting(
+		"head_pitch_offset", "Head pitch offset",
 		{ "min" : -1.0, "max" : 1.0 },
 		"advanced")
 	add_tracked_setting(
@@ -1435,8 +1440,11 @@ func _process(delta):
 				head_quat_array[1] * head_quat_multiplier[1],
 				head_quat_array[2] * head_quat_multiplier[2],
 				head_quat_array[3] * head_quat_multiplier[3])).get_euler()
+			var head_basis_target := Basis.from_euler(head_euler * head_rotation_scale)
+			# Rotating the head by the x axis to allow for pitch offset
+			head_basis_target = head_basis_target.rotated(head_basis_target.x, head_pitch_offset)
 			$Head.transform.basis = $Head.transform.basis.slerp(
-				Basis.from_euler(head_euler * head_rotation_scale),
+				head_basis_target,
 				delta_scale * 0.5) # FIXME: Hardcoded smoothing.
 		else:
 


### PR DESCRIPTION
I added a slider for offsetting the base pitch of the head. This is useful for me since my webcam is on top of my monitor, so the camera thinks I am looking down.

I added a tracked setting to the advanced section of the MediaPipeController mod called "Head pitch offset" and a corresponding variable head_pitch_offset. The variable rotates the head around it's X basis.

For ease of viewing I pulled the head basis creation into it's own variable.