### PR TITLE
Fix window focus

### DIFF
--- a/Core/UI/BasicSubWindow.tscn
+++ b/Core/UI/BasicSubWindow.tscn
@@ -92,6 +92,7 @@ focus_mode = 0
 theme_override_font_sizes/font_size = 10
 text = "x"
 
+[connection signal="gui_input" from="." to="." method="_on_gui_input"]
 [connection signal="resized" from="." to="." method="_on_resized"]
 [connection signal="gui_input" from="WindowBorder" to="." method="_on_window_border_gui_input"]
 [connection signal="mouse_entered" from="WindowBorder" to="." method="_on_window_border_mouse_entered"]


### PR DESCRIPTION
### Problem

When multiple `BaseSubWindow`s are open and you click between them, the clicked window does not always get moved in front properly, unless specifically the title bar or border is clicked. Additionally, when a window is moved in front, the control of another window may still have focus, so tab and arrow keys still affect it.

From my understanding, this is because a window can't (and shouldn't) take focus directly, as the code has previously assumed it could due to the `grab_focus()` calls.

### Solution

- Create a `set_window_in_front` function to replace `_on_focus_entered`.
- Replace calls to `_on_focus_entered` and `grab_focus` with simply `set_window_in_front`.
- Connect to the window's own `gui_input` to also call `set_window_in_front`. Without it, clicking the inside of the window, or any sub-control, would not pull the window in front.
- Connect to viewport's `gui_focus_changed` to see if any of the window's own controls got focused, call `set_window_in_front` if so. When clicking an interactive (and presumably also focusable) control such as a `Button`, the GUI event does not (by default) get passed upward. So this seems to be a solid way to ensure the window is correctly moved in front.
- When a window is moved in front, and another window's controls are currently focused, the focus is cleared.

### Notes

- `is_window_in_front` is technically unused but may be useful, so I left it in. Can remove from PR if requested.
- I removed typing to fit with the other code in the file, but I could add it back in if requested.
- I did a quick check to make sure everything works even if the windows are popped out, and it seems to be fine.