### PR TITLE
Vrm bonemap

### DIFF
--- a/Core/ModelController.gd
+++ b/Core/ModelController.gd
@@ -121,35 +121,7 @@ func get_skeleton() -> Skeleton3D:
 # Find a bone index based on the VRM bone name. This can be different from the
 # bone name on the model itself. These names match the Unity humanoid.
 func find_mapped_bone_index(bone_name : String):
-	var bone_mapping = $Model.vrm_meta.humanoid_bone_mapping
-
-	# Forcefully convert the bone name into the form of one uppercase letter
-	# then all lowercase. eg foo -> Foo, FOO -> Foo, etc. This seems to be
-	# the convention of the VRM importer or just the exporter I'm using.
-	#var fixed_bone_name = bone_name[0].to_lower() + bone_name.substr(1)
-	var fixed_bone_name = bone_name
-
-	var skeleton : Skeleton3D = get_skeleton()
-	
-	var bone_index = bone_mapping.profile.find_bone(fixed_bone_name)
-	if bone_index != -1:
-		
-		var mapped_bone_name = bone_mapping.get_skeleton_bone_name(fixed_bone_name)
-		if mapped_bone_name != "":
-			#var mapped_bone_name = bone_mapping[fixed_bone_name]
-		
-			var bone_index2 = skeleton.find_bone(mapped_bone_name)
-			#print("  MAPPED BONE: ", mapped_bone_name, " ", bone_index2)
-			if bone_index2 != -1:
-				return bone_index2
-
-	# Couldn't find the mapped bone name. Attempt to find the bone directly on
-	# the model.
-	var bone_index3 = skeleton.find_bone(fixed_bone_name)
-	if bone_index3 != -1:
-		return bone_index3
-
-	return -1
+	return _bone_name_to_idx_map.get(bone_name, -1)
 
 ## Get a bone's "global" (local to the skeleton objectm not the scene) pose.
 func get_bone_transform(bone_name : String):

--- a/Mods/Base/Mod_Base.gd
+++ b/Mods/Base/Mod_Base.gd
@@ -390,10 +390,14 @@ func get_model() -> Node3D:
 	var controller = get_app().get_node("ModelController")
 	return controller.get_node_or_null("Model")
 
-func get_bone_transform(bone_name) -> Transform3D:
+func get_bone_idx_from_name(bone_name: String) -> int:
+	var controller = get_app().get_node("ModelController")
+	return controller.find_mapped_bone_index(bone_name)
+
+func get_bone_transform(bone_name: String) -> Transform3D:
 	var skeleton = get_skeleton()
 	if skeleton:
-		var bone_index = skeleton.find_bone(bone_name)
+		var bone_index = get_bone_idx_from_name(bone_name)
 		if bone_index != -1:
 			return skeleton.get_bone_global_pose(bone_index)
 	return Transform3D()

--- a/Mods/MediaPipe/MediaPipeController.gd
+++ b/Mods/MediaPipe/MediaPipeController.gd
@@ -391,8 +391,8 @@ func _setup_ik_chains():
 	
 	var chain_spine : MediaPipeController_IKChain = MediaPipeController_IKChain.new()
 	chain_spine.skeleton = get_skeleton()
-	chain_spine.base_bone = "Hips"
-	chain_spine.tip_bone = "Head"
+	chain_spine.base_bone_index = get_skeleton().find_bone("Hips")
+	chain_spine.tip_bone_index = get_skeleton().find_bone("Head")
 	chain_spine.rotation_low = 0.0 * PI
 	chain_spine.rotation_high = 2.0 * PI
 	chain_spine.do_yaw = true
@@ -427,8 +427,8 @@ func _setup_ik_chains():
 
 		var chain_hand = MediaPipeController_IKChain.new()
 		chain_hand.skeleton = get_skeleton()
-		chain_hand.base_bone = side + "UpperArm"
-		chain_hand.tip_bone = side + "Hand"
+		chain_hand.base_bone_index = get_skeleton().find_bone(side + "UpperArm")
+		chain_hand.tip_bone_index = get_skeleton().find_bone(side + "Hand")
 		#chain_hand.tip_bone = side + "IndexProximal"
 		chain_hand.rotation_low = 0.05 * PI
 		chain_hand.rotation_high = 2.0 * 0.99 * PI
@@ -937,7 +937,7 @@ func _process(delta):
 			var tracker_local_position = \
 				skel.get_global_transform().inverse() * tracker_to_use.get_global_transform()
 			var base_bone_position = skel.get_bone_global_pose(
-				skel.find_bone(_ikchains[k].base_bone)).origin
+				_ikchains[k].base_bone_index).origin
 			#print(tracker_local_position.origin.x - bone_position.x)
 			
 			# See if we can raise the shoulders for when arms go too far up.

--- a/Mods/MediaPipe/MediaPipeController_IKChain.gd
+++ b/Mods/MediaPipe/MediaPipeController_IKChain.gd
@@ -3,8 +3,8 @@ class_name MediaPipeController_IKChain
 
 # FIXME: We pass this around internally a bunch and don't need to.
 var skeleton : Skeleton3D = null
-var base_bone : String
-var tip_bone : String
+var base_bone_index : int
+var tip_bone_index : int
 
 var tracker_object : Node = null
 
@@ -332,8 +332,6 @@ func do_ik_chain():
 	if _calculated_distance_to_angle_mappings == null:	
 		evaluate_bone_chain_limit()
 	
-	var base_bone_index = skeleton.find_bone(base_bone)
-	var tip_bone_index = skeleton.find_bone(tip_bone)
 	var current_bone_index = tip_bone_index
 
 	# Reset all rotations.
@@ -490,9 +488,6 @@ func attempt_spine_rotation(
 		
 func evaluate_bone_chain_limit():
 	
-	var base_bone_index = skeleton.find_bone(base_bone)
-	var tip_bone_index = skeleton.find_bone(tip_bone)
-	
 	var n = rotation_low
 	
 	var found_max_extension_angle = 0.0
@@ -562,11 +557,6 @@ func evaluate_bone_chain_limit():
 func reset_bone_chain(
 	skel : Skeleton3D,
 	base_bone_index, tip_bone_index):
-
-	if base_bone_index is String:
-		base_bone_index = skel.find_bone(base_bone_index)
-	if tip_bone_index is String:
-		tip_bone_index = skel.find_bone(tip_bone_index)
 
 	var current_bone_index = tip_bone_index
 	while current_bone_index != -1:


### PR DESCRIPTION
So I noticed the VRM specs come with a mapping between bone names and indexes which you don't seem to use yet. Tbh I half suspect there's a good reason for that that I'm not aware of, but if not, this could be a big change for the reliability and spec compatability of SnekStudio.

I changed the current way of matching bone names to indexes (basically making assumptions about the exporting program's naming scheme and then using Skeleton3D's find_bone function) with helper functions using a mapping of VRM bones to bone indexes, read from the gltf import's json dictionary. Something along those changes may also have improved performance on my weak laptop from mid-30 to mid-40 fps, according to the outputs (may be accidental, I haven't properly tested this).

I made relevant changes to the ModelController itself and the MediaPipeController. I didn't look at the other plugins yet, but they *should* be simple to update: 
- for scripts based on Mod_Base, replace bone index lookups with  calls to get_bone_idx_from_name() with the VRM bone name (see https://github.com/vrm-c/vrm-specification/blob/master/specification/VRMC_vrm-1.0/schema/VRMC_vrm.humanoid.humanBones.schema.json)
- for other scripts, move bone index lookups to the caller

VRM 0.0 models seem to work as before, as far as I could notice. VRM 1.0 models still need more work - right now they fail at an assert that from a glance seems related to spring bone handling and not to my changes.