### PR TITLE
Make CI build flatpaks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,22 +16,9 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-latest
     container: debian:bookworm
-
+    outputs:
+      version: ${{ steps.ver_exp.outputs.VERSION }}
     steps:
-
-      # Create the release, I guess?
-    - name: Create Release
-      id: create_release
-      uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        tag_name: ${{ github.ref }}
-        release_name: Release ${{ github.ref }}
-        body: Auto generated release
-        draft: true
-        prerelease: false
-
       # Install git.
     - name: Git
       run: |
@@ -48,9 +35,55 @@ jobs:
     - name: Build
       run: |
         Build/run_this_inside_debian_container_to_build.bsh
+    # set the version for flatpak
+    - name: Version Export
+      id: ver_exp
+      run: |
+        source Build/build_vars.sh
+        echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
 
-    - name: Upload Assets to Release with a wildcard
-      uses: shogo82148/actions-upload-release-asset@v1
+    - name: Upload built files as artifact
+      uses: actions/upload-artifact@v4
       with:
-        asset_path: "Build/Builds/Dist/SnekStudio_*"
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        name: build-output
+        path: Build/Builds/Dist/
+    
+  flatpak:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+        # Create the release, I guess?
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          body: Auto generated release
+          draft: true
+          prerelease: false
+      
+      # check out git repository.
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+       # download build artifacts from build
+      - name: Download build output
+        uses: actions/download-artifact@v4
+        with:
+          name: build-output
+          path: Build/Builds/Dist/
+      - name: set VERSION
+        run: echo "VERSION=${{ needs.build.outputs.version}}" >> $GITHUB_ENV
+      - name: Build
+        run: |
+            Build/run_this_inside_ubuntu_after_build.bsh
+          
+    
+      - name: Upload Assets to Release with a wildcard
+        uses: shogo82148/actions-upload-release-asset@v1
+        with:
+          asset_path: "Build/Builds/Dist/SnekStudio_*"
+          upload_url: ${{ steps.create_release.outputs.upload_url }}

--- a/Build/build_flatpak_after_build.bsh
+++ b/Build/build_flatpak_after_build.bsh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+cd Build/Builds
+
+# set up flatpak files
+cp ../../flatpak/* .
+sed -i "s|AMD64_ARCHIVE|Dist/SnekStudio_Linux-x86_64_${VERSION}.tar.gz|g" com.snekstudio.Snekstudio.yaml
+sed -i "s|ARM64_ARCHIVE|Dist/SnekStudio_Linux-arm64_${VERSION}.tar.gz|g" com.snekstudio.Snekstudio.yaml
+
+flatpak-builder build-dir --force-clean com.snekstudio.Snekstudio.yaml --repo=snudio_repo
+
+# this is mega slow to build, we need to have icons pre made of various sizes
+# to stop building imagemagick to resize the icons
+flatpak-builder --arch=aarch64 build-dir --force-clean com.snekstudio.Snekstudio.yaml --repo=snudio_repo
+
+# bundle everything into single files that can be installed
+
+flatpak build-bundle snudio_repo Dist/com.snekstudio.Snekstudio.flatpak com.snekstudio.Snekstudio

--- a/Build/run_this_inside_ubuntu_after_build.bsh
+++ b/Build/run_this_inside_ubuntu_after_build.bsh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -e
+
+cd Build
+
+bash ./setup_ubuntu.sh
+
+cd Builds
+
+
+# set up flatpak files
+cp ../../flatpak/* .
+sed -i "s|AMD64_ARCHIVE|Dist/SnekStudio_Linux-x86_64_${VERSION}.tar.gz|g" com.snekstudio.Snekstudio.yaml
+sed -i "s|ARM64_ARCHIVE|Dist/SnekStudio_Linux-arm64_${VERSION}.tar.gz|g" com.snekstudio.Snekstudio.yaml
+
+flatpak-builder --force-clean --repo=snudio-x86_64 build-dir com.snekstudio.Snekstudio.yaml
+echo "bundling for x86_64, this can look like its locked up. its not"
+flatpak build-bundle snudio-x86_64 com.snekstudio.Snekstudio-x86_64.flatpak com.snekstudio.Snekstudio --runtime-repo=https://flathub.org/repo/flathub.flatpakrepo
+
+# this is like mega slow we need icons of various sizes
+# if we have them we can skip building imagemagick
+flatpak-builder --force-clean --arch=aarch64 --repo=snudio-aarch64 build-dir com.snekstudio.Snekstudio.yaml
+echo "bundling for aarch64, this can look like its locked up. its not"
+flatpak build-bundle --arch=aarch64 snudio-aarch64 com.snekstudio.Snekstudio-aarch64.flatpak com.snekstudio.Snekstudio --runtime-repo=https://flathub.org/repo/flathub.flatpakrepo
+
+cp *.flatpak Dist

--- a/Build/setup_ubuntu.sh
+++ b/Build/setup_ubuntu.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e
+
+apt update
+apt install -y flatpak flatpak-builder binfmt-support qemu-user-static
+
+flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+
+# install platform and sdk for both aarch64 and x86_64 so we can build both flatpaks
+flatpak install -y \
+    org.freedesktop.Sdk/x86_64/24.08 \
+    org.freedesktop.Platform/x86_64/24.08 \
+    org.freedesktop.Sdk/aarch64/24.08 \
+    org.freedesktop.Platform/aarch64/24.08

--- a/flatpak/com.snekstudio.Snekstudio.desktop
+++ b/flatpak/com.snekstudio.Snekstudio.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Name=SnekStudio
+GenericName=VTuber Software
+Comment=Open-source VTuber software
+Exec=/app/bin/snekstudio-runner
+Icon=com.snekstudio.Snekstudio
+Terminal=false
+Type=Application
+Categories=Video;AudioVideo;
+StartupNotify=true
+StartupWMClass=SnekStudio

--- a/flatpak/com.snekstudio.Snekstudio.metainfo.xml
+++ b/flatpak/com.snekstudio.Snekstudio.metainfo.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+    <id>com.snekstudio.Snekstudio</id>
+
+    <name>Snek Studio</name>
+    <summary>Open-source VTuber software using Godot Engine!</summary>
+    <url type="homepage">https://snekstudio.com</url>
+    <metadata_license>CC0-1.0</metadata_license>
+    <project_license>GPL-3.0-or-later</project_license>
+    <content_rating type="oars-1.1" />
+    <developer id="com.expiredpopsicle">
+        <name>ExpiredPopsicle</name>
+    </developer>
+    <description>
+        <p>
+            SnekStudio is a free, open-source VTuber application written using the Godot engine!
+        </p>
+        <p>
+            Features include:
+        </p>
+        <p>
+            VRM Support Use a standard model format shared across many tools and applications
+            already. A MediaPipe-based Tracking System Capable of 50 different face blendshapes and
+            hand tracking. VMC Receiver Support For those who would like to import real-time
+            tracking data from other software. Modular Architecture Designed to be easily extended
+            through self-contained modules written in GDScript, or just simple Godot scenes. Twitch
+            Integration Let your viewers throw stuff at your face for channel points! Twitch redeem
+            functionality can be extended in GDScript for other actions. Fully Open-Source It&apos;s
+            free! And you can modify it! Linux Desktop Support Built to fill a gap in the VTubing
+            space, which previously excluded most Linux desktop users.
+        </p>
+    </description>
+
+    <launchable type="desktop-id">com.snekstudio.Snekstudio.desktop</launchable>
+    <screenshots>
+        <screenshot type="default">
+            <image>https://snekstudio.com/img/thumbsup_small.jpg</image>
+            <caption>sammy the default model holding a thumbs up</caption>
+        </screenshot>
+    </screenshots>
+    <releases>
+        <release version="v0.1.4" date="2025-06-17">
+            <description>
+                <p>Doing a release right before Offkai!</p>
+                <p>(Also because a bunch of stuff has been fixed since the last release.)</p>
+            </description>
+        </release>
+    </releases>
+</component>

--- a/flatpak/com.snekstudio.Snekstudio.yaml
+++ b/flatpak/com.snekstudio.Snekstudio.yaml
@@ -1,0 +1,69 @@
+app-id: com.snekstudio.Snekstudio
+runtime: org.freedesktop.Platform
+runtime-version: "24.08"
+sdk: org.freedesktop.Sdk
+command: snekstudio-runner
+finish-args:
+  - --share=ipc
+  - --socket=x11
+  - --socket=pulseaudio
+  - --device=all
+  - --share=network
+modules:
+  - name: magick
+    config-opts:
+      - --disable-docs
+    sources:
+      - type: git
+        url: https://github.com/ImageMagick/ImageMagick.git
+        commit: 3fcd081c0278427fc0e8ac40ef75c0a1537792f7
+        tag: 7.1.2-0
+        x-checker-data:
+          type: git
+          tag-pattern: (\d+\.\d+\.\d+-\d+)
+    cleanup:
+      - "*"
+  - name: snekstudio
+    buildsystem: "simple"
+    build-options:
+      append-path: /app/bin
+    build-commands:
+      - install -Dm644 snekstudio.pck -t ${FLATPAK_DEST}/bin/
+      - install -Dm755 snekstudio -t ${FLATPAK_DEST}/bin/
+      - install -Dm755 snekstudio-runner.sh ${FLATPAK_DEST}/bin/snekstudio-runner
+      - mkdir -p ${FLATPAK_DEST}/share/SnekStudio
+      - cp -r Mods ${FLATPAK_DEST}/share/SnekStudio
+      - cp -r SampleModels ${FLATPAK_DEST}/share/SnekStudio
+    post-install:
+      - install -D com.snekstudio.Snekstudio.desktop -t  /app/share/applications/
+      - install -D com.snekstudio.Snekstudio.metainfo.xml -t /app/share/metainfo/
+      - magick convert kiri_smug.png -resize 32x32 32x32.png
+      - magick convert kiri_smug.png -resize 64x64 64x64.png
+      - magick convert kiri_smug.png -resize 128x128 128x128.png
+      - magick convert kiri_smug.png -resize 256x256 256x256.png
+      - magick convert kiri_smug.png -resize 512x512 512x512.png
+      - install -Dm644 32x32.png  /app/share/icons/hicolor/32x32/apps/$FLATPAK_ID.png
+      - install -Dm644 64x64.png  /app/share/icons/hicolor/64x64/apps/$FLATPAK_ID.png
+      - install -Dm644 128x128.png  /app/share/icons/hicolor/128x128/apps/$FLATPAK_ID.png
+      - install -Dm644 256x256.png  /app/share/icons/hicolor/256x256/apps/$FLATPAK_ID.png
+      - install -Dm644 512x512.png  /app/share/icons/hicolor/512x512/apps/$FLATPAK_ID.png
+    sources:
+      - type: archive
+        path: AMD64_ARCHIVE
+      - type: archive
+        path: ARM64_ARCHIVE
+      - type: file
+        path: com.snekstudio.Snekstudio.desktop
+      - type: file
+        path: com.snekstudio.Snekstudio.metainfo.xml
+      - type: file
+        url: https://github.com/ExpiredPopsicle/SnekStudio/blob/v0.1.4/Core/UI/Images/kiri_smug.png?raw=true
+        sha256: 7e3317ba3213859ad3dc723713e01604b27fa776fddbe1029d978b611a2ecc45
+      - type: script
+        dest-filename: snekstudio-runner.sh
+        commands:
+          - export SNEKSTUDIO_CONFIG_PATH=${XDG_CONFIG_HOME}/SnekStudio
+          - export SNEKSTUDIO_CACHE_PATH=${XDG_CACHE_HOME}/SnekStudio
+          - export SNEKSTUDIO_MODS_PATHS="/app/share/SnekStudio/Mods:${XDG_CONFIG_HOME}/SnekStudio/Mods"
+          - export SNEKSTUDIO_SAMPLE_PATH="/app/share/SnekStudio/SampleModels"
+          - mkdir -p ${XDG_CONFIG_HOME}/SnekStudio/Mods && /app/bin/snekstudio


### PR DESCRIPTION
This adds a flatpak as a build artifact. The flatpaks are built from the tarballs produced by the build script. This however requires 2 jobs as flatpak can not install the required Sdk and Platform inside a container as it requires a running dbus impl.

To work around this, this break the existing workflow into 2 jobs. First we build snudio as normal, then instead of uploadingit as a release, we then upload them as build artifacts. Then the second job downloads the built artifacts and builds the flatpaks before publishing a release.

We can greatly reduce the build time for the flatpak if we have a icon for the flatpak already scaled to the following sizes, 32x32, 64x64, 128x128, 256x256, 512x512. This would mean we can drop building imagemagick and just bundle snudio.