### PR TITLE
Separate 3D camera to subviewport, added environment settings from 4.4

### DIFF
--- a/Core/CameraBoom/CameraBoom.tscn
+++ b/Core/CameraBoom/CameraBoom.tscn
@@ -2,7 +2,7 @@
 
 [ext_resource type="Script" uid="uid://br24fa3ct4n62" path="res://Core/CameraBoom/CameraBoom.gd" id="1_dxg52"]
 
-[node name="CameraBoom" type="Node3D"]
+[node name="CameraBoom" type="Node3D" unique_id=827507908]
 script = ExtResource("1_dxg52")
 
 [node name="Camera3D" type="Camera3D" parent="."]

--- a/Core/Main.gd
+++ b/Core/Main.gd
@@ -33,18 +33,15 @@ func get_background_color():
 	return current_style.bg_color
 
 func set_background_color(c : Color):
-	var env = get_node("WorldEnvironment")
-	var env2 : Environment = env.environment
-	env2.background_color = c
+	# var env = get_node("WorldEnvironment")
+	# var env2 : Environment = env.environment
+	# env2.background_color = c
 	
 	var current_style : StyleBoxFlat = %BackgroundPanel.get("theme_override_styles/panel")
 	current_style.bg_color = c
 
 func set_background_transparency(transparent : bool):
 	if transparent:
-		var env = get_node("WorldEnvironment")
-		var env2 : Environment = env.environment
-		env2.background_mode = Environment.BG_CLEAR_COLOR
 		get_node("BackgroundLayer").visible = false
 		get_tree().get_root().set_transparent_background(true) # Needed for compatibility mode.
 		
@@ -55,10 +52,7 @@ func set_background_transparency(transparent : bool):
 #		get_tree().root.transparent_bg = true
 		
 	else:
-		var env = get_node("WorldEnvironment")
-		var env2 : Environment = env.environment
-		env2.background_mode = Environment.BG_CANVAS
-		#env2.background_color = Color(1.0, 1.0, 1.0, 1.0)
+		# env2.background_color = Color(1.0, 1.0, 1.0, 1.0)
 		get_node("BackgroundLayer").visible = true
 		get_tree().get_root().set_transparent_background(false) # Needed for compatibility mode.
 
@@ -99,7 +93,8 @@ func _load_mods() -> void:
 	_mods_loaded = true
 
 func _ready():
-	
+	%CameraBoom/Camera3D.environment = Environment.new()
+
 	_load_mods()
 
 	set_background_transparency(true)
@@ -266,7 +261,7 @@ func reset_settings_to_default() -> void:
 		child.queue_free()
 
 	# Reset camera.
-	$CameraBoom.reset_to_default()
+	%CameraBoom.reset_to_default()
 
 	# Reset transparency.	
 	set_background_transparency(true)
@@ -298,7 +293,7 @@ func serialize_settings(do_settings=true, do_mods=true):
 	if do_settings:
 		
 		# Save camera.
-		settings_to_save["camera"] = $CameraBoom.save_settings()
+		settings_to_save["camera"] = %CameraBoom.save_settings()
 
 		# Save UI visibility.
 		settings_to_save["ui_visible"] = %UI_Root.visible
@@ -427,7 +422,7 @@ func deserialize_settings(settings_dict, do_settings=true, do_mods=true):
 
 		# Load camera.
 		if "camera" in settings_dict:
-			$CameraBoom.load_settings(settings_dict["camera"])
+			%CameraBoom.load_settings(settings_dict["camera"])
 
 		# Load transparency.
 		if "transparent_window" in settings_dict:

--- a/Core/Main.tscn
+++ b/Core/Main.tscn
@@ -10,20 +10,6 @@
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_nh3ai"]
 bg_color = Color(1, 0.164706, 0.776471, 1)
 
-[sub_resource type="ProceduralSkyMaterial" id="ProceduralSkyMaterial_jmxhl"]
-sky_energy_multiplier = 7.83
-
-[sub_resource type="Sky" id="Sky_1idd5"]
-sky_material = SubResource("ProceduralSkyMaterial_jmxhl")
-
-[sub_resource type="Environment" id="Environment_w4pqy"]
-background_mode = 3
-background_color = Color(0.952941, 0, 0.835294, 1)
-sky = SubResource("Sky_1idd5")
-ambient_light_source = 2
-ambient_light_color = Color(1, 1, 1, 1)
-reflected_light_source = 1
-
 [sub_resource type="AudioStreamMicrophone" id="AudioStreamMicrophone_djr57"]
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_fauey"]
@@ -38,10 +24,27 @@ script = ExtResource("1_88riu")
 [node name="CanvasLayer2" type="CanvasLayer" parent="." unique_id=599508500]
 layer = 2
 
+[node name="SubViewportContainer" type="SubViewportContainer" parent="CanvasLayer2"]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+stretch = true
+
+[node name="SubViewport" type="SubViewport" parent="CanvasLayer2/SubViewportContainer"]
+transparent_bg = true
+handle_input_locally = false
+size = Vector2i(1152, 648)
+
+[node name="CameraBoom" parent="CanvasLayer2/SubViewportContainer/SubViewport" instance=ExtResource("3_ur4kn")]
+unique_name_in_owner = true
+transform = Transform3D(1, 0, 0, 0, 0.994522, 0.104528, 0, -0.104528, 0.994522, 0, 1.45, 0)
+
 [node name="UI_Root" parent="CanvasLayer2" unique_id=539242864 node_paths=PackedStringArray("controller", "camera_boom") instance=ExtResource("2_a0eek")]
 unique_name_in_owner = true
 controller = NodePath("../../ModelController")
-camera_boom = NodePath("../../CameraBoom")
+camera_boom = NodePath("../SubViewportContainer/SubViewport/CameraBoom")
 
 [node name="BackgroundLayer" type="CanvasLayer" parent="." unique_id=1279483787]
 layer = -1
@@ -55,9 +58,6 @@ grow_horizontal = 2
 grow_vertical = 2
 theme_override_styles/panel = SubResource("StyleBoxFlat_nh3ai")
 
-[node name="CameraBoom" parent="." unique_id=827507908 instance=ExtResource("3_ur4kn")]
-transform = Transform3D(1, 0, 0, 0, 0.994522, 0.104528, 0, -0.104528, 0.994522, 0, 1.45, 0)
-
 [node name="Mods" type="Node" parent="." unique_id=2137161948]
 unique_name_in_owner = true
 
@@ -65,10 +65,8 @@ unique_name_in_owner = true
 transform = Transform3D(1, 0, 3.49691e-07, 0, 1, 0, -3.49691e-07, 0, 1, 0, 0, 0)
 script = ExtResource("5_upw4c")
 
-[node name="WorldEnvironment" type="WorldEnvironment" parent="." unique_id=1477399033]
-environment = SubResource("Environment_w4pqy")
-
 [node name="AudioStreamRecord" type="AudioStreamPlayer" parent="." unique_id=2117267123]
+
 stream = SubResource("AudioStreamMicrophone_djr57")
 bus = &"Record"
 script = ExtResource("10_dpnxj")

--- a/Mods/Anaglyph3D/Anaglyph3D.gd
+++ b/Mods/Anaglyph3D/Anaglyph3D.gd
@@ -79,8 +79,8 @@ func _process(delta: float) -> void:
 	subviewport_right.size = get_viewport().size
 
 	# Position cameras, initially copying main camera.
-	var boom: Node3D = get_app().get_node("CameraBoom")
-	var original_cam: Camera3D = boom.get_node("Camera3D")
+	var boom: Node3D = get_app().get_node("%CameraBoom")
+	var original_cam: Camera3D = boom.get_node("%CameraBoom/Camera3D")
 	var original_cam_transform: Transform3D = original_cam.global_transform
 	var cam_left: Camera3D = subviewport_left.get_node("Camera3D")
 	cam_left.global_transform = original_cam_transform
@@ -111,14 +111,14 @@ func scene_init() -> void:
 	# Move subviewports from this object to the camera boom in the main scene.
 	remove_child(subviewport_left)
 	remove_child(subviewport_right)
-	var boom: Node3D = get_app().get_node("CameraBoom")
+	var boom: Node3D = get_app().get_node("%CameraBoom")
 	boom.add_child(subviewport_left)
 	boom.add_child(subviewport_right)
 
 func scene_shutdown() -> void:
 
 	# Move subviewports back into this scene.
-	var boom: Node3D = get_app().get_node("CameraBoom")
+	var boom: Node3D = get_app().get_node("%CameraBoom")
 	boom.remove_child(subviewport_left)
 	boom.remove_child(subviewport_right)
 	add_child(subviewport_left)

--- a/Mods/CameraPositions/camera_positions.gd
+++ b/Mods/CameraPositions/camera_positions.gd
@@ -41,7 +41,7 @@ func _ready():
 
 func _get_camera() -> Node3D:
 	var app = get_app()
-	var cam_child = app.find_child("CameraBoom", false)
+	var cam_child = app.get_node("%CameraBoom")
 	assert(cam_child != null)
 	return cam_child
 

--- a/Mods/Scene_Basic/Scene_Basic.tscn
+++ b/Mods/Scene_Basic/Scene_Basic.tscn
@@ -1,32 +1,13 @@
-[gd_scene load_steps=7 format=3 uid="uid://bgoav4n60htm2"]
+[gd_scene load_steps=4 format=3 uid="uid://bgoav4n60htm2"]
 
 [ext_resource type="Script" uid="uid://7quu5svg8jeg" path="res://Mods/Scene_Basic/Scene_Basic.gd" id="1_qx82q"]
 [ext_resource type="Material" uid="uid://bi00jwt1yfcby" path="res://Core/Materials/TriplanarGridMaterial.tres" id="2_udkp6"]
-
-[sub_resource type="ProceduralSkyMaterial" id="ProceduralSkyMaterial_wvywh"]
-sky_energy_multiplier = 7.83
-
-[sub_resource type="Sky" id="Sky_2mrp7"]
-sky_material = SubResource("ProceduralSkyMaterial_wvywh")
-
-[sub_resource type="Environment" id="Environment_tf4s1"]
-background_mode = 3
-background_color = Color(0.952941, 0, 0.835294, 1)
-background_energy_multiplier = 0.5
-sky = SubResource("Sky_2mrp7")
-ambient_light_source = 2
-ambient_light_color = Color(1, 1, 1, 1)
-ambient_light_energy = 0.5
-reflected_light_source = 1
 
 [sub_resource type="PlaneMesh" id="PlaneMesh_d4h00"]
 size = Vector2(10, 10)
 
 [node name="SceneBasic" type="Node3D"]
 script = ExtResource("1_qx82q")
-
-[node name="WorldEnvironment" type="WorldEnvironment" parent="."]
-environment = SubResource("Environment_tf4s1")
 
 [node name="DirectionalLight3D" type="DirectionalLight3D" parent="."]
 transform = Transform3D(0.844865, -0.251842, 0.471996, -0.109142, 0.782572, 0.612918, -0.523729, -0.569347, 0.633681, 3.96731, 2.64172, -1.05663)


### PR DESCRIPTION
Had some issues with draw order. 

Changing the WorldEnvironment meant also changing the UI environment settings, like tonemap and exposure. To seperate the background colour from the tonemap changes, a subviewport is used. 

This might have a performance impact, but I think the ability to customize the 3d environment is worth it. Lmk if there's a better way.

Closes #139 