### PR TITLE
Fix intermittent freeze on exit

### DIFF
--- a/Mods/MediaPipe/MediaPipeController.gd
+++ b/Mods/MediaPipe/MediaPipeController.gd
@@ -63,9 +63,9 @@ var head_position_smoothing : float = 2.0
 
 var hand_confidence_time_threshold = 1.0
 var hand_count_change_time_threshold = 1.0
-var min_hand_detection_confidence = 0.5
-var min_hand_tracking_confidence = 0.5
-var min_hand_presence_confidence = 0.5
+var min_hand_detection_confidence = 0.75
+var min_hand_tracking_confidence = 0.75
+var min_hand_presence_confidence = 0.9
 
 var hand_rotation_smoothing : float = 2.0
 var hand_position_smoothing : float = 4.0

--- a/Mods/MediaPipe/MediaPipeController.gd
+++ b/Mods/MediaPipe/MediaPipeController.gd
@@ -432,8 +432,7 @@ func _start_tracker():
 
 func _stop_tracker():
 
-	tracker_python_process.call_rpc_sync(
-		"stop_tracker", [])
+	tracker_python_process.stop_process()
 
 	set_status("Stopped")
 

--- a/Mods/MediaPipe/MediaPipeController.gd
+++ b/Mods/MediaPipe/MediaPipeController.gd
@@ -396,24 +396,9 @@ func _scan_video_devices():
 	# Create a fake "None" entry.
 	_devices_list.insert(0, "None")
 	_devices_by_list_entry["None"] = { "index" : -1 }
-
-func _start_tracker():
 	
-	tracker_python_process.call_rpc_async(
-		"set_udp_port_number", [_udp_port])
-
-	tracker_python_process.call_rpc_async(
-		"set_hand_confidence_time_threshold", [hand_confidence_time_threshold])
-		
-	tracker_python_process.call_rpc_async(
-		"set_hand_detection_confidence", [min_hand_detection_confidence])
-		
-	tracker_python_process.call_rpc_async(
-		"set_hand_tracking_confidence", [min_hand_tracking_confidence])
-		
-	tracker_python_process.call_rpc_async(
-		"set_hand_presence_confidence", [min_hand_presence_confidence])
-
+	
+func _get_video_device_index():
 	var video_device_index_to_use = 0
 	
 	if len(video_device) > 0:
@@ -422,12 +407,25 @@ func _start_tracker():
 			video_device_index_to_use = int(actual_device_data["index"])
 	else:
 		video_device_index_to_use = -1
+	return video_device_index_to_use
 
-	# FIXME: Replace this all with a single settings dict.
+func _start_tracker():
+
+	var video_device_index = _get_video_device_index()
+		
 	tracker_python_process.call_rpc_async(
-		"set_video_device_number", [video_device_index_to_use])
-	tracker_python_process.call_rpc_async(
-		"set_hand_count_change_time_threshold", [hand_count_change_time_threshold])
+		"update_settings", [{
+			"video_device_number" : video_device_index,
+			"udp_port_number" : _udp_port,
+			"hand_position_scale"  : _vec3_to_array(hand_position_scale),
+			"hand_position_offset" : _vec3_to_array(hand_position_offset),
+			"hand_confidence_time_threshold" : hand_confidence_time_threshold,
+			"hand_count_change_time_threshold" : hand_count_change_time_threshold,
+			"hand_to_head_scale"   : hand_to_head_scale,
+			"hand_detection_confidence": min_hand_detection_confidence,
+			"hand_tracking_confidence": min_hand_tracking_confidence,
+			"hand_presence_confidence": min_hand_presence_confidence
+		}])
 
 	tracker_python_process.call_rpc_async(
 		"start_tracker", [])
@@ -441,6 +439,7 @@ func _stop_tracker():
 
 func _send_settings_to_tracker():
 
+	var video_device_number : int = -1;
 	# Don't send these if the tracker process isn't running. We'll send them
 	# after it starts, instead (called in _start_process).
 	if tracker_python_process.get_status() != KiriPythonWrapperInstance.KiriPythonWrapperStatus.STATUS_RUNNING:
@@ -453,36 +452,20 @@ func _send_settings_to_tracker():
 			video_device.clear()
 
 	# Set the video device.
-	if len(video_device):
-		var actual_device_data = _devices_by_list_entry[video_device[0]]
-		tracker_python_process.call_rpc_async(
-			"set_video_device_number", [actual_device_data["index"]])
-	else:
-		# If no camera selected, then select device -1.
-		tracker_python_process.call_rpc_async(
-			"set_video_device_number", [-1])
+	video_device_number = _get_video_device_index();
 
-	tracker_python_process.call_rpc_async(
-		"set_hand_confidence_time_threshold", [hand_confidence_time_threshold])
-		
-	tracker_python_process.call_rpc_async(
-		"set_hand_count_change_time_threshold", [hand_count_change_time_threshold])
-		
-	tracker_python_process.call_rpc_async(
-		"set_hand_detection_confidence", [min_hand_detection_confidence])
-		
-	tracker_python_process.call_rpc_async(
-		"set_hand_tracking_confidence", [min_hand_tracking_confidence])
-		
-	tracker_python_process.call_rpc_async(
-		"set_hand_presence_confidence", [min_hand_presence_confidence])
-
-	# FIXME: Replace all of the above with this one call.
 	tracker_python_process.call_rpc_async(
 		"update_settings", [{
+			"video_device_number" : video_device_number,
+			#"udp_port_number" : _udp_port,
 			"hand_position_scale"  : _vec3_to_array(hand_position_scale),
 			"hand_position_offset" : _vec3_to_array(hand_position_offset),
-			"hand_to_head_scale"   : hand_to_head_scale
+			"hand_confidence_time_threshold" : hand_confidence_time_threshold,
+			"hand_count_change_time_threshold" : hand_count_change_time_threshold,
+			"hand_to_head_scale"   : hand_to_head_scale,
+			"hand_detection_confidence": min_hand_detection_confidence,
+			"hand_tracking_confidence": min_hand_tracking_confidence,
+			"hand_presence_confidence": min_hand_presence_confidence
 		}])
 
 #endregion

--- a/Mods/MediaPipe/MediaPipeController.gd
+++ b/Mods/MediaPipe/MediaPipeController.gd
@@ -63,6 +63,9 @@ var head_position_smoothing : float = 2.0
 
 var hand_confidence_time_threshold = 1.0
 var hand_count_change_time_threshold = 1.0
+var min_hand_detection_confidence = 0.5
+var min_hand_tracking_confidence = 0.5
+var min_hand_presence_confidence = 0.5
 
 var hand_rotation_smoothing : float = 2.0
 var hand_position_smoothing : float = 4.0
@@ -113,15 +116,38 @@ func _ready():
 
 	add_setting_group("advanced", "Advanced")
 
-
+	# It should probably be called "confidence time before hand tracking starts"
 	add_tracked_setting(
-		"hand_confidence_time_threshold", "Hand confidence time",
+		"hand_confidence_time_threshold", "Confidence time before hand tracking starts",
 		{ "min" : 0.0, "max" : 20.0 },
 		"advanced")
+	# "Time to wait before registering hands after we detected that the number of hands has changed."
+	# This seems to be connected to the freeze on exit described in issue 78
+	# https://github.com/ExpiredPopsicle/SnekStudio/issues/78
 	add_tracked_setting(
-		"hand_count_change_time_threshold", "Hand count change time",
+		"hand_count_change_time_threshold", "Confidence time before hand count changes",
 		{ "min" : 0.0, "max" : 20.0 },
 		"advanced")
+		
+	# Connects to min_hand_detection_confidence, min_tracking_confidence, and
+	# min_hand_presence_confidence respectively in new_tracker.py
+	add_tracked_setting(
+		"min_hand_detection_confidence", "Minimum hand detection confidence level (%)",
+		{ "min" : 0.0, "max" : 1.0 },
+		"advanced"
+	)
+	
+	add_tracked_setting(
+		"min_hand_tracking_confidence", "Minimum hand tracking confidence level (%)",
+		{ "min" : 0.0, "max" : 1.0 },
+		"advanced"
+	)
+	
+	add_tracked_setting(
+		"min_hand_presence_confidence", "Minimum hand presence confidence level (%)",
+		{ "min" : 0.0, "max" : 1.0 },
+		"advanced"
+	)
 
 	add_tracked_setting(
 		"frames_missing_before_spine_reset", "Untracked frames before reset",
@@ -378,6 +404,15 @@ func _start_tracker():
 
 	tracker_python_process.call_rpc_async(
 		"set_hand_confidence_time_threshold", [hand_confidence_time_threshold])
+		
+	tracker_python_process.call_rpc_async(
+		"set_hand_detection_confidence", [min_hand_detection_confidence])
+		
+	tracker_python_process.call_rpc_async(
+		"set_hand_tracking_confidence", [min_hand_tracking_confidence])
+		
+	tracker_python_process.call_rpc_async(
+		"set_hand_presence_confidence", [min_hand_presence_confidence])
 
 	var video_device_index_to_use = 0
 	
@@ -432,6 +467,15 @@ func _send_settings_to_tracker():
 		
 	tracker_python_process.call_rpc_async(
 		"set_hand_count_change_time_threshold", [hand_count_change_time_threshold])
+		
+	tracker_python_process.call_rpc_async(
+		"set_hand_detection_confidence", [min_hand_detection_confidence])
+		
+	tracker_python_process.call_rpc_async(
+		"set_hand_tracking_confidence", [min_hand_tracking_confidence])
+		
+	tracker_python_process.call_rpc_async(
+		"set_hand_presence_confidence", [min_hand_presence_confidence])
 
 	# FIXME: Replace all of the above with this one call.
 	tracker_python_process.call_rpc_async(

--- a/Mods/MediaPipe/_tracker/Project/new_tracker.py
+++ b/Mods/MediaPipe/_tracker/Project/new_tracker.py
@@ -690,7 +690,6 @@ class MediaPipeTracker:
 
     # Set to -1 to just release all devices.
     #
-    # FIXME: Merge into update_settings.
     def set_video_device_number(self, new_number):
 
         if self.video_device_index != new_number:
@@ -699,41 +698,50 @@ class MediaPipeTracker:
             self._close_video_device()
             self._open_video_device()
 
-    # FIXME: Merge into update_settings.
-    def set_udp_port_number(self, new_number):
-        with self.the_big_ugly_mutex:
-            self.udp_port_number = new_number
-
-    # FIXME: Merge into update_settings.
-    def set_hand_confidence_time_threshold(self, new_number):
-        with self.the_big_ugly_mutex:
-            self.confidence_time_threshold = new_number
-
-    def set_hand_detection_confidence(self, new_number):
-        with self.the_big_ugly_mutex:
-            self.hand_detection_confidence = new_number
-
-    def set_hand_tracking_confidence(self, new_number):
-        with self.the_big_ugly_mutex:
-            self.hand_tracking_confidence = new_number
-
-    def set_hand_presence_confidence(self, new_number):
-        with self.the_big_ugly_mutex:
-            self.hand_presence_confidence = new_number
-
-    # FIXME: Merge into update_settings.
-    def set_hand_count_change_time_threshold(self, new_number):
-        with self.the_big_ugly_mutex:
-            self.time_since_hand_count_changed_threshold = new_number
-
     def update_settings(self, new_settings_dict):
+        # TODO: use mutex here
+        if "video_device_number" in new_settings_dict:
+            set_video_device_number(new_settings_dict["video_device_number"])
+
+        if "udp_port_number" in new_settings_dict:
+            with self.the_big_ugly_mutex:
+                self.udp_port_number = new_settings_dict["udp_port_number"]
+
+        if "video_device_number" in new_settings_dict:
+            with self.the_big_ugly_mutex:
+                self.video_device_index = new_settings_dict["video_device_number"]
+
+        if "set_hand_confidence_time_threshold" in new_settings_dict:
+            with self.the_big_ugly_mutex:
+                self.hand_detection_confidence = new_settings_dict["set_hand_confidence_time_threshold"]
+
+        if  "hand_count_change_time_threshold" in new_settings_dict:
+            with self.the_big_ugly_mutex:
+                self.time_since_hand_count_changed_threshold = new_settings_dict["hand_count_change_time_threshold"]
 
         if "hand_position_scale" in new_settings_dict:
-            self.hand_position_scale = new_settings_dict["hand_position_scale"]
+            with self.the_big_ugly_mutex:
+                self.hand_position_scale = new_settings_dict["hand_position_scale"]
+
         if "hand_position_offset" in new_settings_dict:
-            self.hand_position_offset = new_settings_dict["hand_position_offset"]
+            with self.the_big_ugly_mutex:
+                self.hand_position_offset = new_settings_dict["hand_position_offset"]
+
         if "hand_to_head_scale" in new_settings_dict:
-            self.hand_to_head_scale = new_settings_dict["hand_to_head_scale"]
+            with self.the_big_ugly_mutex:
+                self.hand_to_head_scale = new_settings_dict["hand_to_head_scale"]
+
+        if "hand_detection_confidence" in new_settings_dict:
+            with self.the_big_ugly_mutex:
+                self.hand_detection_confidence = new_settings_dict["hand_detection_confidence"]
+
+        if "hand_tracking_confidence" in new_settings_dict:
+            with self.the_big_ugly_mutex:
+                self.hand_tracking_confidence = new_settings_dict["hand_tracking_confidence"]
+
+        if "hand_presence_confidence" in new_settings_dict:
+            with self.the_big_ugly_mutex:
+                self.hand_tracking_confidence = new_settings_dict["hand_presence_confidence"]
 
     def _shutdown_mediapipe(self):
 

--- a/Mods/MediaPipe/_tracker/Project/new_tracker.py
+++ b/Mods/MediaPipe/_tracker/Project/new_tracker.py
@@ -96,9 +96,10 @@ class MediaPipeTracker:
         # the number of hands has changed.
         self.time_since_hand_count_changed_threshold = 1.0
 
-        self.hand_detection_confidence = 0.5
-        self.hand_tracking_confidence = 0.5
-        self.hand_presence_confidence = 0.5
+        # Were working in the 4.1 version.
+        self.hand_detection_confidence = 0.75
+        self.hand_tracking_confidence = 0.75
+        self.hand_presence_confidence = 0.9
 
         self.hand_position_scale = numpy.array([7.0, 7.0, 3.5])
         self.hand_position_offset = numpy.array([0.0, -0.14, 0.0])

--- a/Mods/MediaPipe/_tracker/Project/new_tracker.py
+++ b/Mods/MediaPipe/_tracker/Project/new_tracker.py
@@ -699,9 +699,8 @@ class MediaPipeTracker:
             self._open_video_device()
 
     def update_settings(self, new_settings_dict):
-        # TODO: use mutex here
         if "video_device_number" in new_settings_dict:
-            set_video_device_number(new_settings_dict["video_device_number"])
+            self.set_video_device_number(new_settings_dict["video_device_number"])
 
         if "udp_port_number" in new_settings_dict:
             with self.the_big_ugly_mutex:
@@ -781,28 +780,6 @@ def start_tracker():
 def stop_tracker():
     global mediapipe_controller
     mediapipe_controller.stop_tracker()
-
-# Set to -1 to just release all devices.
-#
-# FIXME: Merge into update_settings.
-def set_video_device_number(new_number):
-    global mediapipe_controller
-    mediapipe_controller.set_video_device_number(new_number)
-
-# FIXME: Merge into update_settings.
-def set_udp_port_number(new_number):
-    global mediapipe_controller
-    mediapipe_controller.set_udp_port_number(new_number)
-
-# FIXME: Merge into update_settings.
-def set_hand_confidence_time_threshold(new_number):
-    global mediapipe_controller
-    mediapipe_controller.set_hand_confidence_time_threshold(new_number)
-
-# FIXME: Merge into update_settings.
-def set_hand_count_change_time_threshold(new_number):
-    global mediapipe_controller
-    mediapipe_controller.set_hand_count_change_time_threshold(new_number)
 
 def update_settings(new_settings_dict):
     global mediapipe_controller

--- a/Mods/MediaPipe/_tracker/Project/new_tracker.py
+++ b/Mods/MediaPipe/_tracker/Project/new_tracker.py
@@ -96,6 +96,10 @@ class MediaPipeTracker:
         # the number of hands has changed.
         self.time_since_hand_count_changed_threshold = 1.0
 
+        self.hand_detection_confidence = 0.5
+        self.hand_tracking_confidence = 0.5
+        self.hand_presence_confidence = 0.5
+
         self.hand_position_scale = numpy.array([7.0, 7.0, 3.5])
         self.hand_position_offset = numpy.array([0.0, -0.14, 0.0])
         self.hand_to_head_scale = 2.0
@@ -174,11 +178,9 @@ class MediaPipeTracker:
             running_mode = VisionRunningMode.LIVE_STREAM,
             num_hands = 2,
 
-            # FIXME: Make these adjustable.
-            # Were working in the 4.1 version.
-            min_hand_detection_confidence = 0.75,
-            min_tracking_confidence = 0.75,
-            min_hand_presence_confidence = 0.9,
+            min_hand_detection_confidence = self.hand_detection_confidence,
+            min_tracking_confidence = self.hand_tracking_confidence,
+            min_hand_presence_confidence = self.hand_presence_confidence,
 
             result_callback = self._handle_result_hands)
 
@@ -706,6 +708,18 @@ class MediaPipeTracker:
     def set_hand_confidence_time_threshold(self, new_number):
         with self.the_big_ugly_mutex:
             self.confidence_time_threshold = new_number
+
+    def set_hand_detection_confidence(self, new_number):
+        with self.the_big_ugly_mutex:
+            self.hand_detection_confidence = new_number
+
+    def set_hand_tracking_confidence(self, new_number):
+        with self.the_big_ugly_mutex:
+            self.hand_tracking_confidence = new_number
+
+    def set_hand_presence_confidence(self, new_number):
+        with self.the_big_ugly_mutex:
+            self.hand_presence_confidence = new_number
 
     # FIXME: Merge into update_settings.
     def set_hand_count_change_time_threshold(self, new_number):


### PR DESCRIPTION
Fixes #78 in the simplest brute force way I could think of: just kill the tracker process instead of calling the stop function through RPC. 

If we really need a graceful exit for the tracker, I had some thoughts of trying to use SIGTERM or CTRL_BREAK_EVENT to terminate the process in a way that hopefully bypasses the backlogged RPC issue.

I also addressed some FIXMEs I found along the way, including refactoring of `update_settings`.