### PR TITLE
KiriOSC: Resolve hostnames

### DIFF
--- a/Mods/VMCController/KiriOSC/KiriOSCClient.gd
+++ b/Mods/VMCController/KiriOSC/KiriOSCClient.gd
@@ -9,6 +9,8 @@ var ntp_start_unix : int
 @export var target_port : int = 39539
 @export var auto_start : bool = false
 
+var target_ip_resolved : String = IP.resolve_hostname(target_ip)
+
 func _ready():
 	ntp_start_date = Time.get_datetime_dict_from_datetime_string("1900-01-01T00:00:00Z", false)
 	ntp_start_unix = Time.get_unix_time_from_datetime_dict(ntp_start_date)
@@ -19,6 +21,7 @@ func _ready():
 func change_port_and_ip(port : int, ip : String) -> void:
 	if target_ip != ip or target_port != port:
 		target_ip = ip
+		target_ip_resolved = IP.resolve_hostname(ip)
 		target_port = port
 		if is_client_active():
 			stop_client()
@@ -27,7 +30,7 @@ func change_port_and_ip(port : int, ip : String) -> void:
 ## Connect to host.
 func start_client() -> void:
 	udp_peer = PacketPeerUDP.new()
-	udp_peer.connect_to_host(target_ip, target_port)
+	udp_peer.connect_to_host(target_ip_resolved, target_port)
 
 ## Disconnect from host.
 func stop_client() -> void:

--- a/Mods/VMCController/KiriOSC/KiriOSCServer.gd
+++ b/Mods/VMCController/KiriOSC/KiriOSCServer.gd
@@ -7,6 +7,8 @@ var udp_peer : PacketPeerUDP = null
 @export var host_port : int = 39567
 @export var auto_start : bool = true
 
+var host_ip_resolved : String = IP.resolve_hostname(host_ip)
+
 signal message_received(address, arguments)
 
 var _errors_since_last_check = []
@@ -21,6 +23,7 @@ func _add_error(new_error):
 func change_port_and_ip(port, ip):
 	if host_ip != ip or host_port != port:
 		host_ip = ip
+		host_ip_resolved = IP.resolve_hostname(ip)
 		host_port = port
 		if is_server_active():
 			stop_server()
@@ -28,7 +31,7 @@ func change_port_and_ip(port, ip):
 
 func start_server():
 	udp_peer = PacketPeerUDP.new()
-	var err = udp_peer.bind(host_port, host_ip)
+	var err = udp_peer.bind(host_port, host_ip_resolved)
 	if err != OK:
 		_add_error("Failed to bind port!")
 		udp_peer.close()


### PR DESCRIPTION
Allows hostnames like `localhost` to be used as OSC addresses.