### PR TITLE
Fix file filters not working in file dialogs for Mods

### DIFF
--- a/Mods/Base/Mod_Base.gd
+++ b/Mods/Base/Mod_Base.gd
@@ -183,7 +183,8 @@ func add_tracked_setting(
 		new_widget = settings_window_add_lineedit(
 			new_setting_prop["label"], new_setting_prop["name"],
 			new_setting_prop["args"].get("is_redeem", false),
-			new_setting_prop["args"].get("is_fileaccess", false))
+			new_setting_prop["args"].get("is_fileaccess", false),
+			new_setting_prop["args"].get("file_filters", []))
 
 	elif prop_val is bool:
 		new_widget = settings_window_add_boolean(new_setting_prop["label"], new_setting_prop["name"])


### PR DESCRIPTION
Was wondering why the file filter wasn't working for picking the background in Scene_basic, and realized that we forgot to add the argument to it.