### PR TITLE
Support pattern matching in ModelToggle mod

### DIFF
--- a/Mods/ModelToggle/ModelToggle.gd
+++ b/Mods/ModelToggle/ModelToggle.gd
@@ -9,28 +9,23 @@ var currently_toggled : bool = false
 var current_time_until_undo : float = 0.0
 
 func scene_init():
-	var skel = get_skeleton()
-	var model = skel.get_node_or_null(model_name)
-	if model:
-		model.visible = !start_hidden
+	if model_name:
+		for model in get_skeleton().find_children(model_name, "Node3D"):
+			model.visible = !start_hidden
 
 func _reset_visibility():
-	var skel = get_skeleton()
-	var model = skel.get_node_or_null(model_name)
-	if model:
-		model.visible = true
+	if model_name:
+		for model in get_skeleton().find_children(model_name, "Node3D"):
+			model.visible = true
 
 func scene_shutdown():
 	_reset_visibility()
-	
+
 func _update_model():
-	var skel = get_skeleton()
-	var model = skel.get_node_or_null(model_name)
-	if model:
-		if currently_toggled:
-			model.visible = start_hidden
-		else:
-			model.visible = !start_hidden
+	if model_name:
+		var model_visible := currently_toggled == start_hidden
+		for model in get_skeleton().find_children(model_name, "Node3D"):
+			model.visible = model_visible
 
 func handle_channel_point_redeem(_redeemer_username, _redeemer_display_name, _redeem_title, _user_input):
 	if _redeem_title == redeem_name:


### PR DESCRIPTION
My model has some parts that are separate, but should be shown/hidden as a unit, so I would have to create multiple `ModelToggle` mods for each part, all using the same redeem as a trigger. In some cases, the parts of the model share part of their name. So I figured it'd be nice to "fuzzily" match node names and apply to multiple at the same time, which thankfully, [`find_children`](https://docs.godotengine.org/en/stable/classes/class_node.html#class-node-method-find-children) already supports.

I decided to filter for only `Node3D` nodes, as those have the `visible` property we care about. And I enabled recursive search, since objects attached to bones may appear as children of those bones in the skeleton, apparently.

There is the possibility to create a helper method (such as `models_set_visibility(bool)` or so) to deduplicate code, but I decided to keep the changes straight-forward. If desired, I could include this suggestion.

### Example

Model has "Belt", "Belt_Buckle", "Belt_Pouch" parts.
Specify `Belt*` for Model Name to be able to toggle visibility of all three at once.