### PR TITLE
Flatpak extension support

### DIFF
--- a/flatpak/com.snekstudio.Snekstudio.yaml
+++ b/flatpak/com.snekstudio.Snekstudio.yaml
@@ -9,6 +9,14 @@ finish-args:
   - --socket=pulseaudio
   - --device=all
   - --share=network
+add-extensions:
+  com.snekstudio.Snekstudio.Mod:
+    directory: user-mods
+    merge-dirs: user-mods
+    add-ld-path: lib
+    subdirectories: false
+    no-autodownload: true
+    autodelete: true
 modules:
   - name: snekstudio
     buildsystem: "simple"
@@ -22,6 +30,7 @@ modules:
       - cp -r Mods ${FLATPAK_DEST}/share/SnekStudio
       - cp -r SampleModels ${FLATPAK_DEST}/share/SnekStudio
     post-install:
+      - mkdir -p ${FLATPAK_DEST}/user-mods
       - install -D com.snekstudio.Snekstudio.desktop -t  /app/share/applications/
       - install -D com.snekstudio.Snekstudio.metainfo.xml -t /app/share/metainfo/
       - install -Dm644 32x32.png  /app/share/icons/hicolor/32x32/apps/$FLATPAK_ID.png
@@ -49,6 +58,6 @@ modules:
         commands:
           - export SNEKSTUDIO_CONFIG_PATH=${XDG_CONFIG_HOME}/SnekStudio
           - export SNEKSTUDIO_CACHE_PATH=${XDG_CACHE_HOME}/SnekStudio
-          - export SNEKSTUDIO_MODS_PATHS="/app/share/SnekStudio/Mods:${XDG_CONFIG_HOME}/SnekStudio/Mods"
+          - export SNEKSTUDIO_MODS_PATHS="/app/share/SnekStudio/Mods:/app/user-mods:${XDG_CONFIG_HOME}/SnekStudio/Mods"
           - export SNEKSTUDIO_SAMPLE_PATH="/app/share/SnekStudio/SampleModels"
           - mkdir -p ${XDG_CONFIG_HOME}/SnekStudio/Mods && /app/bin/snekstudio "$@"

--- a/flatpak/com.snekstudio.Snekstudio.yaml
+++ b/flatpak/com.snekstudio.Snekstudio.yaml
@@ -1,6 +1,6 @@
 app-id: com.snekstudio.Snekstudio
 runtime: org.freedesktop.Platform
-runtime-version: "24.08"
+runtime-version: "25.08"
 sdk: org.freedesktop.Sdk
 command: snekstudio-runner
 finish-args:


### PR DESCRIPTION
This pr updates the freedesktop runtime to 25.08 the latest. It also adds support for supplying mods via extensions through the `com.snekstudio.Snekstudio.Mod` namespace so a mods name LunasSuperCoolMod would be have the id ideally as `com.snekstudio.Snekstudio.Mod.LunasSuperCoolMod`. Mods supplied through this method would be stored in `/app/user-mods` to prevent clobbering of the mods shipped by snekstudio. This does add `/lib` to the ld path, I don't think we should need it. However, if someone makes a mod that uses GDNative, this might become useful.