### PR TITLE
Force shut down tracker process

### DIFF
--- a/Mods/MediaPipe/MediaPipeController.gd
+++ b/Mods/MediaPipe/MediaPipeController.gd
@@ -409,8 +409,7 @@ func _start_tracker():
 
 func _stop_tracker():
 
-	tracker_python_process.call_rpc_sync(
-		"stop_tracker", [])
+	tracker_python_process.stop_process()
 
 	set_status("Stopped")
 


### PR DESCRIPTION
Basically #160 with only the fix for the intermittent freeze on exit (resolves #78). 

From debugging, it seems like the hand tracking can create a massive backlog of RPC calls that all have to be processed before the shutdown call. I just kill the tracker process directly instead of waiting for the RPC calls.